### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ end
 In `config/test.exs` specify the endpoint to be used for routing requests:
 
 ```elixir
-config :phoenix_test, :endpoint, MyApp.Endpoint
+config :phoenix_test, :endpoint, MyAppWeb.Endpoint
 ```
 
 ### Adding a `FeatureCase`


### PR DESCRIPTION
I'm probably nitpicking here, but the `Endpoint` module is usually created in the `*Web` namespace 😉 