### PR TITLE
Raise AssertionError instead of RuntimeError

### DIFF
--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -2,6 +2,7 @@ defmodule PhoenixTest.Assertions do
   @moduledoc false
 
   import ExUnit.Assertions
+  alias ExUnit.AssertionError
 
   alias PhoenixTest.Query
 
@@ -14,18 +15,20 @@ defmodule PhoenixTest.Assertions do
         assert true
 
       {:not_found, []} ->
-        raise """
-        Could not find any elements with selector #{inspect(selector)}.
-        """
+        raise AssertionError,
+          message: """
+          Could not find any elements with selector #{inspect(selector)}.
+          """
 
       {:not_found, elements_matched_selector} ->
-        raise """
-        Could not find element with text #{inspect(text)}.
+        raise AssertionError,
+          message: """
+          Could not find element with text #{inspect(text)}.
 
-        Found other elements matching the selector #{inspect(selector)}:
+          Found other elements matching the selector #{inspect(selector)}:
 
-        #{format_found_elements(elements_matched_selector)}
-        """
+          #{format_found_elements(elements_matched_selector)}
+          """
     end
 
     session
@@ -40,20 +43,22 @@ defmodule PhoenixTest.Assertions do
         refute false
 
       {:found, element} ->
-        raise """
-        Expected not to find an element.
+        raise AssertionError,
+          message: """
+          Expected not to find an element.
 
-        But found an element with selector #{inspect(selector)} and text #{inspect(text)}:
+          But found an element with selector #{inspect(selector)} and text #{inspect(text)}:
 
-        #{format_found_element(element)}
-        """
+          #{format_found_element(element)}
+          """
 
       {:found_many, elements} ->
-        raise """
-        Expected not to find an element.
+        raise AssertionError,
+          message: """
+          Expected not to find an element.
 
-        But found #{Enum.count(elements)} elements with selector #{inspect(selector)} and text #{inspect(text)}:
-        """
+          But found #{Enum.count(elements)} elements with selector #{inspect(selector)} and text #{inspect(text)}:
+          """
     end
 
     session


### PR DESCRIPTION
Currently, assertions `assert_has` and `refute_has` raise `RuntimeError`

```
  1) test index shows empty states (Manage.PageLiveTest)
     apps/manage/test/manage/live/page_test.exs:6
     ** (RuntimeError) Could not find any elements with selector "span#bar".

     code: |> assert_has("span#bar", "foo")
     stacktrace:
       (phoenix_test 0.2.1) lib/phoenix_test/assertions.ex:17: PhoenixTest.Assertions.assert_has/3
       test/manage/live/page_test.exs:9: (test)
```

This works, but it's more common for assertion helpers to raise `ExUnit.AssertionError` instead, as it signals that
there is something wrong with what the test author is asserting vs. something wrong with the setup as such.

This PR introduces `AssertionError` to the `Assertions` module, and only there. This is how output of the same test
looks like:

```
  1) test index shows empty states (Manage.PageLiveTest)
     apps/manage/test/manage/live/page_test.exs:6
     Could not find any elements with selector "span#bar".

     code: |> assert_has("span#bar", "foo")
     stacktrace:
       (phoenix_test 0.2.1) lib/phoenix_test/assertions.ex:18: PhoenixTest.Assertions.assert_has/3
       test/manage/live/page_test.exs:9: (test)
```

