### PR TITLE
Use Floki to find nested fields

### DIFF
--- a/lib/phoenix_test/html/form.ex
+++ b/lib/phoenix_test/html/form.ex
@@ -15,13 +15,11 @@ defmodule PhoenixTest.Html.Form do
   end
 
   defp build_fields(fields) do
-    fields
-    |> Enum.filter(fn
-      {"input", _, _} -> true
-      {"select", _, _} -> true
-      {"textarea", _, _} -> true
-      _ -> false
-    end)
+    inputs = fields |> Floki.find("input")
+    selects = fields |> Floki.find("select")
+    textareas = fields |> Floki.find("textarea")
+
+    Enum.concat([inputs, selects, textareas])
     |> Enum.map(&create_field/1)
   end
 

--- a/test/phoenix_test/html/form_test.exs
+++ b/test/phoenix_test/html/form_test.exs
@@ -58,6 +58,24 @@ defmodule PhoenixTest.Html.FormTest do
 
       assert %{"type" => "checkbox"} = admin
     end
+
+    test "parses nested checkbox" do
+      data =
+        form_data("""
+          <form id="user-form" action="/" method="post">
+            <div>
+              <label for="admin">Admin</label>
+              <input type="checkbox" name="admin" />
+            </div>
+          </form>
+        """)
+
+      %{"fields" => fields} = Html.Form.parse(data)
+
+      admin = Enum.find(fields, &(&1["name"] == "admin"))
+
+      assert %{"type" => "checkbox"} = admin
+    end
   end
 
   defp form_data(html_form) do

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -139,13 +139,15 @@ defmodule PhoenixTest.StaticTest do
         name: "Aragorn",
         admin: "on",
         race: "human",
-        notes: "King of Gondor"
+        notes: "King of Gondor",
+        member_of_fellowship: "on"
       )
       |> click_button("Save")
       |> assert_has("#form-data", "name: Aragorn")
       |> assert_has("#form-data", "admin: on")
       |> assert_has("#form-data", "race: human")
       |> assert_has("#form-data", "notes: King of Gondor")
+      |> assert_has("#form-data", "member_of_fellowship: on")
     end
 
     test "raises an error when form cannot be found with given selector", %{conn: conn} do

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -68,6 +68,11 @@ defmodule PhoenixTest.PageView do
       <label for="notes">Notes</label>
       <textarea name="notes" rows="5" cols="33">
       </textarea>
+
+      <div>
+        <label for="member_of_fellowship">Member of fellowship</label>
+        <input type="checkbox" name="member_of_fellowship" />
+      </div>
     </form>
     """
   end


### PR DESCRIPTION
In the current version, `fill_form` can't be used if the fields are no direct children of the form element.
This PR changes the `build_fields` function to use Floki in order to find all input, select and textarea elements that are somewhere in the tree of the form element.