### PR TITLE
Support file input with plug upload

### DIFF
--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -133,6 +133,9 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
   defp validate_expected_fields(existing_fields, form_data) do
     form_data
     |> Enum.each(fn
+      {key, %Plug.Upload{}} ->
+        verify_field_presence(existing_fields, to_string(key))
+
       {key, values} when is_map(values) ->
         Enum.each(values, fn {nested_key, nested_value} ->
           combined_key = "#{to_string(key)}[#{to_string(nested_key)}]"

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -139,13 +139,19 @@ defmodule PhoenixTest.StaticTest do
         name: "Aragorn",
         admin: "on",
         race: "human",
-        notes: "King of Gondor"
+        notes: "King of Gondor",
+        image: %Plug.Upload{
+          content_type: "image/png",
+          filename: "aragorn.png",
+          path: "test/fixtures/aragorn.png"
+        }
       )
       |> click_button("Save")
       |> assert_has("#form-data", "name: Aragorn")
       |> assert_has("#form-data", "admin: on")
       |> assert_has("#form-data", "race: human")
       |> assert_has("#form-data", "notes: King of Gondor")
+      |> assert_has("#form-data", "image: aragorn.png")
     end
 
     test "raises an error when form cannot be found with given selector", %{conn: conn} do

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -68,6 +68,9 @@ defmodule PhoenixTest.PageView do
       <label for="notes">Notes</label>
       <textarea name="notes" rows="5" cols="33">
       </textarea>
+
+      <label for="image">Image</label>
+      <input accept="image/*" type="file" name="image" />
     </form>
     """
   end
@@ -120,6 +123,10 @@ defmodule PhoenixTest.PageView do
 
   defp render_input_data(key, value) when is_binary(value) do
     "#{key}: #{value}"
+  end
+
+  defp render_input_data(key, %Plug.Upload{filename: filename}) do
+    "#{key}: #{filename}"
   end
 
   defp render_input_data(key, values) do


### PR DESCRIPTION
When using an input field for a file, the `validate_expected_fields` function raises.

This PR solves this issue but includes `Plug.Upload` pattern matches in some functions. I was not quite sure whether this is a good approach but wanted to suggest the solution anyway.