### PR TITLE
Handle form redirects in Live pages

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -126,35 +126,11 @@ defmodule PhoenixTest.LiveTest do
       assert starting_html == ending_html
     end
 
-    test "can handle forms with inputs, checkboxes, selects, textboxes", %{conn: conn} do
-      conn
-      |> visit("/live/index")
-      |> fill_form("#full-form",
-        name: "Aragorn",
-        admin: "on",
-        race: "human",
-        notes: "King of Gondor"
-      )
-      |> click_button("Save")
-      |> assert_has("#form-data", "name: Aragorn")
-      |> assert_has("#form-data", "admin: on")
-      |> assert_has("#form-data", "race: human")
-      |> assert_has("#form-data", "notes: King of Gondor")
-    end
-
     test "triggers a phx-change event on a form (when it has one)", %{conn: conn} do
       conn
       |> visit("/live/index")
       |> fill_form("#email-form", email: nil)
       |> assert_has("#form-errors", "Errors present")
-    end
-
-    test "can be combined with click_button to submit a form", %{conn: conn} do
-      conn
-      |> visit("/live/index")
-      |> fill_form("#email-form", email: "some@example.com")
-      |> click_button("Save")
-      |> assert_has("#form-data", "email: some@example.com")
     end
 
     test "raises an error when form can't be found with selector", %{conn: conn} do
@@ -182,12 +158,68 @@ defmodule PhoenixTest.LiveTest do
     end
   end
 
+  describe "fill_form + click_button" do
+    test "fill_form can be combined with click_button to submit a form", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_form("#email-form", email: "some@example.com")
+      |> click_button("Save")
+      |> assert_has("#form-data", "email: some@example.com")
+    end
+
+    test "can handle forms with inputs, checkboxes, selects, textboxes", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_form("#full-form",
+        name: "Aragorn",
+        admin: "on",
+        race: "human",
+        notes: "King of Gondor"
+      )
+      |> click_button("Save")
+      |> assert_has("#form-data", "name: Aragorn")
+      |> assert_has("#form-data", "admin: on")
+      |> assert_has("#form-data", "race: human")
+      |> assert_has("#form-data", "notes: King of Gondor")
+    end
+
+    test "follows form's redirect to live page", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_form("#redirect-form", name: "Aragorn")
+      |> click_button("#redirect-form-submit", "Save")
+      |> assert_has("h1", "LiveView page 2")
+    end
+
+    test "follows form's redirect to static page", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_form("#redirect-form-to-static", name: "Aragorn")
+      |> click_button("#redirect-form-to-static-submit", "Save")
+      |> assert_has("h1", "Main page")
+    end
+  end
+
   describe "submit_form/3" do
     test "submits a form via phx-submit", %{conn: conn} do
       conn
       |> visit("/live/index")
       |> submit_form("#email-form", email: "some@example.com")
       |> assert_has("#form-data", "email: some@example.com")
+    end
+
+    test "follows form's redirect to live page", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> submit_form("#redirect-form", name: "Aragorn")
+      |> assert_has("h1", "LiveView page 2")
+    end
+
+    test "follows form's redirect to static page", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> submit_form("#redirect-form-to-static", name: "Aragorn")
+      |> assert_has("h1", "Main page")
     end
 
     test "raises an error if the form can't be found", %{conn: conn} do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -59,6 +59,22 @@ defmodule PhoenixTest.IndexLive do
       <textarea name="notes" rows="5" cols="33">
       </textarea>
     </form>
+
+    <form id="redirect-form" phx-submit="save-redirect-form">
+      <label for="name">Name</label>
+      <input name="name" />
+      <button type="submit" id="redirect-form-submit">
+        Save
+      </button>
+    </form>
+
+    <form id="redirect-form-to-static" phx-submit="save-redirect-form-to-static">
+      <label for="name">Name</label>
+      <input name="name" />
+      <button type="submit" id="redirect-form-to-static-submit">
+        Save
+      </button>
+    </form>
     """
   end
 
@@ -93,6 +109,14 @@ defmodule PhoenixTest.IndexLive do
       |> assign(:form_saved, true)
       |> assign(:form_data, form_data)
     }
+  end
+
+  def handle_event("save-redirect-form", _, socket) do
+    {:noreply, push_navigate(socket, to: "/live/page_2")}
+  end
+
+  def handle_event("save-redirect-form-to-static", _, socket) do
+    {:noreply, redirect(socket, to: "/page/index")}
   end
 
   def handle_event("validate-email", %{"email" => email}, socket) do


### PR DESCRIPTION
Closes #19 

What changed?
============

Our `Live` implementation doesn't handle form redirects, be they to another LiveView with `push_navigate/2` or to a static page via `redirect/2`.

This commit updates the implementation to follow redirects the same way we follow redirects when we click on links.

Testing note
-----------

We also create a new describe block to encapsulate all the testing for `fill_form/3` + `click_button/2`.