### PR TITLE
Handle form redirects in Static pages

### DIFF
--- a/test/support/page_controller.ex
+++ b/test/support/page_controller.ex
@@ -23,4 +23,9 @@ defmodule PhoenixTest.PageController do
     conn
     |> render("record_deleted.html")
   end
+
+  def redirect_to_liveview(conn, _) do
+    conn
+    |> redirect(to: "/live/index")
+  end
 end

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -74,6 +74,21 @@ defmodule PhoenixTest.PageView do
         <input type="checkbox" name="member_of_fellowship" />
       </div>
     </form>
+
+    <form id="redirect-to-liveview-form" method="post" action="/page/redirect_to_liveview">
+      <label for="name">Name</label>
+      <input name="name" />
+      <button type="submit">Save and Redirect to LiveView</button>
+    </form>
+
+    <form method="post" action="/page/redirect_to_liveview">
+      <button>Post and Redirect</button>
+    </form>
+
+    <form id="no-submit-button-and-redirect" method="post" action="/page/redirect_to_liveview">
+      <label for="name">Name</label>
+      <input name="name" />
+    </form>
     """
   end
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -29,6 +29,7 @@ defmodule PhoenixTest.Router do
     put "/page/update_record", PageController, :update
     delete "/page/delete_record", PageController, :delete
     get "/page/:page", PageController, :show
+    post "/page/redirect_to_liveview", PageController, :redirect_to_liveview
 
     live_session :live_pages do
       live "/live/index", IndexLive


### PR DESCRIPTION
What changed?
============

Commit 531e5e9 updated Live form submissions to follow redirects to other LiveView and Static pages.

This commit does the same but for Static pages.

Thus, now when a `fill_form` + `click_button`, a single-field form `click_button`, or a `submit_button` redirects, we follow the redirect to the other page -- whether that be a LiveView or a static page.