### PR TITLE
Handle regular form submission from a LiveView page

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -2,6 +2,7 @@ defmodule PhoenixTest.LiveTest do
   use ExUnit.Case, async: true
 
   import PhoenixTest
+  import PhoenixTest.TestHelpers
 
   alias PhoenixTest.Driver
 
@@ -197,6 +198,29 @@ defmodule PhoenixTest.LiveTest do
       |> fill_form("#redirect-form-to-static", name: "Aragorn")
       |> click_button("#redirect-form-to-static-submit", "Save")
       |> assert_has("h1", "Main page")
+    end
+
+    test "submits regular (non phx-submit) form", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_form("#non-liveview-form", name: "Aragorn")
+      |> click_button("Submit Non LiveView")
+      |> assert_has("h1", "Main page")
+    end
+
+    test "raises an error if form doesn't have a `phx-submit` or `action`", %{conn: conn} do
+      msg =
+        """
+        Expected form with selector "#invalid-form" to have a `phx-submit` or `action` defined.
+        """
+        |> ignore_whitespace()
+
+      assert_raise ArgumentError, msg, fn ->
+        conn
+        |> visit("/live/index")
+        |> fill_form("#invalid-form", name: "Aragorn")
+        |> click_button("Submit Invalid Form")
+      end
     end
   end
 

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -75,6 +75,22 @@ defmodule PhoenixTest.IndexLive do
         Save
       </button>
     </form>
+
+    <form id="invalid-form">
+      <label for="name">Name</label>
+      <input name="name" />
+      <button type="submit">
+        Submit Invalid Form
+      </button>
+    </form>
+
+    <form id="non-liveview-form" action="/page/redirect_to_static" method="post">
+      <label for="name">Name</label>
+      <input name="name" />
+      <button type="submit">
+        Submit Non LiveView
+      </button>
+    </form>
     """
   end
 

--- a/test/support/page_controller.ex
+++ b/test/support/page_controller.ex
@@ -28,4 +28,9 @@ defmodule PhoenixTest.PageController do
     conn
     |> redirect(to: "/live/index")
   end
+
+  def redirect_to_static(conn, _) do
+    conn
+    |> redirect(to: "/page/index")
+  end
 end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -30,6 +30,7 @@ defmodule PhoenixTest.Router do
     delete "/page/delete_record", PageController, :delete
     get "/page/:page", PageController, :show
     post "/page/redirect_to_liveview", PageController, :redirect_to_liveview
+    post "/page/redirect_to_static", PageController, :redirect_to_static
 
     live_session :live_pages do
       live "/live/index", IndexLive


### PR DESCRIPTION
Closes #16

What changed?
=============

Currently, we assume that if you're in a LiveView page, you're trying to submit LiveView forms with `phx-submit`. But people can have regular forms in LiveView pages.

This commit handles that scenario.

In order to handle that we introduce an error message when there are neither a `phx-submit` nor an `action`. In theory, form's don't need an `action`. The form's `action` defaults to the same page (i.e. `"/"`).

But we don't want to just fallback to the normal form if there's no `action`. Instead we want to notify the user of an error -- we should expect a `phx-submit` or an `action`.