### PR TITLE
Failing test for nested field in liveview

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -168,6 +168,14 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", "email: some@example.com")
     end
 
+    test "nested form", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_form("#nested-form", user: %{email: "some@example.com"})
+      |> click_button("Save nested")
+      |> assert_has("#form-data", "email: some@example.com")
+    end
+
     test "can handle forms with inputs, checkboxes, selects, textboxes", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -29,6 +29,11 @@ defmodule PhoenixTest.IndexLive do
       <button type="submit">Save email</button>
     </form>
 
+    <form id="nested-form" phx-submit="save-nested-form">
+      <input name="user[email]" />
+      <button type="submit">Save nested</button>
+    </form>
+
     <div :if={@form_saved} id="form-data">
       <%= for {key, value} <- @form_data do %>
         <%= key %>: <%= value %>


### PR DESCRIPTION
Hi there, thanks for this library, it is sweet as.

I'm seeing the same thing as #17 and have tracked it down to being an issue for LiveView nested form fields. Hopefully this failing test will highlight what's happening

```
mix test
.........................................................................

  1) test fill_form + click_button nested form (PhoenixTest.LiveTest)
     test/phoenix_test/live_test.exs:171
     ** (ArgumentError) Could not find element with selector "#nested-form [name=user]"
     code: |> fill_form("#nested-form", user: %{email: "some@example.com"})
     stacktrace:
       (phoenix_test 0.2.4) lib/phoenix_test/query.ex:9: PhoenixTest.Query.find!/2
       (elixir 1.16.1) lib/enum.ex:987: Enum."-each/2-lists^foreach/1-0-"/2
       (phoenix_test 0.2.4) lib/phoenix_test/live.ex:120: PhoenixTest.Driver.PhoenixTest.Live.fill_form/3
       test/phoenix_test/live_test.exs:174: (test)

......................
Finished in 0.2 seconds (0.2s async, 0.00s sync)
96 tests, 1 failure
```