### PR TITLE
Test nested forms in LiveView

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -192,6 +192,14 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", "notes: King of Gondor")
     end
 
+    test "can submit nested forms", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_form("#nested-form", user: %{name: "Aragorn"})
+      |> click_button("#nested-form", "Save")
+      |> assert_has("#form-data", "user:name: Aragorn")
+    end
+
     test "follows form's redirect to live page", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -31,13 +31,18 @@ defmodule PhoenixTest.IndexLive do
 
     <div :if={@form_saved} id="form-data">
       <%= for {key, value} <- @form_data do %>
-        <%= key %>: <%= value %>
+        <%= render_input_data(key, value) %>
       <% end %>
     </div>
 
     <form id="no-phx-change-form" phx-submit="save-name">
       <input name="name" />
       <button type="submit">Save name</button>
+    </form>
+
+    <form id="nested-form" phx-submit="save-form">
+      <input name="user[name]" />
+      <button type="submit">Save</button>
     </form>
 
     <form id="full-form" phx-submit="save-form">
@@ -143,5 +148,15 @@ defmodule PhoenixTest.IndexLive do
       _valid ->
         {:noreply, socket}
     end
+  end
+
+  defp render_input_data(key, value) when is_binary(value) do
+    "#{key}: #{value}"
+  end
+
+  defp render_input_data(key, values) do
+    Enum.map_join(values, "\n", fn {nested_key, value} ->
+      render_input_data("#{key}:#{nested_key}", value)
+    end)
   end
 end


### PR DESCRIPTION
Fixes #17
Closes #25

What changed?
============

Commit 180dc0d updated our `Live` implementation of form field validations. That fixed an issue that was happening in nested forms in Live that was first documented in https://github.com/germsvel/phoenix_test/issues/17.

A helpful PR https://github.com/germsvel/phoenix_test/pull/25 created a failing test that reproduced the error, and we include a slightly modified version of the test here.

I thought this branch would fix the issue, but the issue was completely resolved by the work in the previously mentioned commit. So, this commit only introduces the additional test.