### PR TITLE
Add assert_has/refute_has "title"

### DIFF
--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -7,6 +7,19 @@ defmodule PhoenixTest.Assertions do
   alias PhoenixTest.Html
   alias PhoenixTest.Query
 
+  def assert_has(session, "title", text) do
+    title = PhoenixTest.Driver.render_page_title(session)
+
+    if title == text do
+      assert true
+    else
+      raise AssertionError,
+        message: """
+        Expected title to be #{inspect(text)} but got #{inspect(title)}
+        """
+    end
+  end
+
   def assert_has(session, selector, text) do
     session
     |> PhoenixTest.Driver.render_html()
@@ -36,6 +49,19 @@ defmodule PhoenixTest.Assertions do
     end
 
     session
+  end
+
+  def refute_has(session, "title", text) do
+    title = PhoenixTest.Driver.render_page_title(session)
+
+    if title == text do
+      raise AssertionError,
+        message: """
+        Expected title not to be #{inspect(text)}
+        """
+    else
+      refute false
+    end
   end
 
   def refute_has(session, selector, text) do

--- a/lib/phoenix_test/driver.ex
+++ b/lib/phoenix_test/driver.ex
@@ -1,5 +1,6 @@
 defprotocol PhoenixTest.Driver do
   @moduledoc false
+  def render_page_title(session)
   def render_html(session)
   def click_link(session, text)
   def click_link(session, selector, text)

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -37,6 +37,10 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   alias PhoenixTest.Html
   alias PhoenixTest.Query
 
+  def render_page_title(%{view: view}) do
+    page_title(view)
+  end
+
   def render_html(%{view: view}) do
     render(view)
   end

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -28,6 +28,16 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
   alias PhoenixTest.Html
   alias PhoenixTest.Query
 
+  def render_page_title(session) do
+    session
+    |> render_html()
+    |> Query.find("title")
+    |> case do
+      {:found, element} -> Html.text(element)
+      _ -> nil
+    end
+  end
+
   def render_html(%{conn: conn}) do
     conn
     |> html_response(200)

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -12,31 +12,21 @@ defmodule PhoenixTest.AssertionsTest do
 
   describe "assert_has/3" do
     test "succeeds if single element is found with CSS selector and text (Static)", %{conn: conn} do
-      conn =
-        conn
-        |> visit("/page/index")
-
-      conn |> assert_has("h1", "Main page")
-
       conn
+      |> visit("/page/index")
+      |> assert_has("h1", "Main page")
       |> assert_has("#title", "Main page")
       |> assert_has(".title", "Main page")
-
-      conn |> assert_has("[data-role='title']", "Main page")
+      |> assert_has("[data-role='title']", "Main page")
     end
 
     test "succeeds if single element is found with CSS selector and text (Live)", %{conn: conn} do
-      conn =
-        conn
-        |> visit("/live/index")
-
-      conn |> assert_has("h1", "LiveView main page")
-
       conn
+      |> visit("/live/index")
+      |> assert_has("h1", "LiveView main page")
       |> assert_has("#title", "LiveView main page")
       |> assert_has(".title", "LiveView main page")
-
-      conn |> assert_has("[data-role='title']", "LiveView main page")
+      |> assert_has("[data-role='title']", "LiveView main page")
     end
 
     test "succeeds if more than one element matches selector but text narrows it down", %{
@@ -91,6 +81,60 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
+    test "can be used to assert on page title (Static)", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> assert_has("title", "PhoenixTest is the best!")
+    end
+
+    test "can be used to assert on page title (Live)", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> assert_has("title", "PhoenixTest is the best!")
+    end
+
+    test "raises if title does not match expected value (Static)", %{conn: conn} do
+      msg =
+        """
+        Expected title to be "Not the title" but got "PhoenixTest is the best!"
+        """
+        |> ignore_whitespace()
+
+      assert_raise AssertionError, msg, fn ->
+        conn
+        |> visit("/page/index")
+        |> assert_has("title", "Not the title")
+      end
+    end
+
+    test "raises if title does not match expected value (Live)", %{conn: conn} do
+      msg =
+        """
+        Expected title to be "Not the title" but got "PhoenixTest is the best!"
+        """
+        |> ignore_whitespace()
+
+      assert_raise AssertionError, msg, fn ->
+        conn
+        |> visit("/live/index")
+        |> assert_has("title", "Not the title")
+      end
+    end
+
+    test "raises if title is contained but is not exactly the same as expected", %{conn: conn} do
+      msg =
+        """
+        Expected title to be "PhoenixTest" but got "PhoenixTest is the best!"
+        """
+        |> ignore_whitespace()
+
+      assert_raise AssertionError, msg, fn ->
+        conn
+        |> visit("/page/index")
+        |> assert_has("title", "PhoenixTest")
+      end
+    end
+
     test "raises error if element cannot be found and selector matches a nested structure", %{
       conn: conn
     } do
@@ -123,32 +167,62 @@ defmodule PhoenixTest.AssertionsTest do
   end
 
   describe "refute_has/3" do
-    test "succeeds if no element is found with CSS selector and text (Static)", %{conn: conn} do
-      conn =
+    test "can be used to refute on page title (Static)", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> refute_has("title", "Not the title")
+    end
+
+    test "can be used to refute on page title (Live)", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> refute_has("title", "Not the title")
+    end
+
+    test "raises if title matches value (Static)", %{conn: conn} do
+      msg =
+        """
+        Expected title not to be "PhoenixTest is the best!"
+        """
+        |> ignore_whitespace()
+
+      assert_raise AssertionError, msg, fn ->
         conn
         |> visit("/page/index")
+        |> refute_has("title", "PhoenixTest is the best!")
+      end
+    end
 
-      conn |> refute_has("h1", "Not main page")
+    test "raises if title matches value (Live)", %{conn: conn} do
+      msg =
+        """
+        Expected title not to be "PhoenixTest is the best!"
+        """
+        |> ignore_whitespace()
 
+      assert_raise AssertionError, msg, fn ->
+        conn
+        |> visit("/live/index")
+        |> refute_has("title", "PhoenixTest is the best!")
+      end
+    end
+
+    test "succeeds if no element is found with CSS selector and text (Static)", %{conn: conn} do
       conn
+      |> visit("/page/index")
+      |> refute_has("h1", "Not main page")
       |> refute_has("h2", "Main page")
       |> refute_has("#incorrect-id", "Main page")
-
-      conn |> refute_has("#title", "Not main page")
+      |> refute_has("#title", "Not main page")
     end
 
     test "succeeds if no element is found with CSS selector and text (Live)", %{conn: conn} do
-      conn =
-        conn
-        |> visit("/live/index")
-
-      conn |> refute_has("h1", "Not main page")
-
       conn
+      |> visit("/live/index")
+      |> refute_has("h1", "Not main page")
       |> refute_has("h2", "Main page")
       |> refute_has("#incorrect-id", "Main page")
-
-      conn |> refute_has("#title", "Not main page")
+      |> refute_has("#title", "Not main page")
     end
 
     test "raises an error if one element is found", %{conn: conn} do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -10,6 +10,36 @@ defmodule PhoenixTest.LiveTest do
     %{conn: Phoenix.ConnTest.build_conn()}
   end
 
+  describe "render_page_title/1" do
+    test "renders the page title", %{conn: conn} do
+      title =
+        conn
+        |> visit("/live/index")
+        |> PhoenixTest.Driver.render_page_title()
+
+      assert title == "PhoenixTest is the best!"
+    end
+
+    test "renders updated page title", %{conn: conn} do
+      title =
+        conn
+        |> visit("/live/index")
+        |> click_button("Change page title")
+        |> PhoenixTest.Driver.render_page_title()
+
+      assert title == "Title changed!"
+    end
+
+    test "returns nil if page title isn't found", %{conn: conn} do
+      title =
+        conn
+        |> visit("/live/index_no_layout")
+        |> PhoenixTest.Driver.render_page_title()
+
+      assert title == nil
+    end
+  end
+
   describe "visit/2" do
     test "navigates to given LiveView page", %{conn: conn} do
       conn

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -7,6 +7,26 @@ defmodule PhoenixTest.StaticTest do
     %{conn: Phoenix.ConnTest.build_conn()}
   end
 
+  describe "render_page_title/1" do
+    test "renders the page title", %{conn: conn} do
+      title =
+        conn
+        |> visit("/page/index")
+        |> PhoenixTest.Driver.render_page_title()
+
+      assert title == "PhoenixTest is the best!"
+    end
+
+    test "renders nil if there's no page title", %{conn: conn} do
+      title =
+        conn
+        |> visit("/page/index_no_layout")
+        |> PhoenixTest.Driver.render_page_title()
+
+      assert title == nil
+    end
+  end
+
   describe "visit/2" do
     test "navigates to given static page", %{conn: conn} do
       conn

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -14,6 +14,8 @@ defmodule PhoenixTest.IndexLive do
 
     <h2 :if={@details}>LiveView main page details</h2>
 
+    <button phx-click="change-page-title">Change page title</button>
+
     <button phx-click="show-tab">Show tab</button>
 
     <div :if={@show_tab} id="tab">
@@ -117,6 +119,10 @@ defmodule PhoenixTest.IndexLive do
       |> assign(:form_data, %{})
       |> assign(:show_form_errors, false)
     }
+  end
+
+  def handle_event("change-page-title", _, socket) do
+    {:noreply, assign(socket, :page_title, "Title changed!")}
   end
 
   def handle_event("show-tab", _, socket) do

--- a/test/support/page_controller.ex
+++ b/test/support/page_controller.ex
@@ -1,7 +1,13 @@
 defmodule PhoenixTest.PageController do
   use Phoenix.Controller
 
-  plug(:put_layout, false)
+  plug(:put_layout, {PhoenixTest.PageView, :layout})
+
+  def show(conn, %{"page" => "index_no_layout"}) do
+    conn
+    |> put_layout({PhoenixTest.PageView, :empty_layout})
+    |> render("index.html")
+  end
 
   def show(conn, %{"page" => page}) do
     conn

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -1,6 +1,25 @@
 defmodule PhoenixTest.PageView do
   use Phoenix.Component
 
+  def render("empty_layout.html", assigns) do
+    ~H"""
+    <%= @inner_content %>
+    """
+  end
+
+  def render("layout.html", assigns) do
+    ~H"""
+    <html lang="en">
+      <head>
+        <title><%= assigns[:page_title] || "PhoenixTest is the best!" %></title>
+      </head>
+      <body>
+        <%= @inner_content %>
+      </body>
+    </html>
+    """
+  end
+
   def render("index.html", assigns) do
     ~H"""
     <h1 id="title" class="title" data-role="title">Main page</h1>

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -32,9 +32,11 @@ defmodule PhoenixTest.Router do
     post "/page/redirect_to_liveview", PageController, :redirect_to_liveview
     post "/page/redirect_to_static", PageController, :redirect_to_static
 
-    live_session :live_pages do
+    live_session :live_pages, root_layout: {PhoenixTest.PageView, :layout} do
       live "/live/index", IndexLive
       live "/live/page_2", Page2Live
     end
+
+    live "/live/index_no_layout", IndexLive
   end
 end


### PR DESCRIPTION
Closes #4

What changed?
=============

We add support to assert and refute the page "title". The title is still visible by a user and is thus nice to support.

Because LiveView's `render/1` only returns the body of the HTML, we have to use LiveViewTest's`page_title/1` helper to get the title.

To keep parity, we introduce a new `render_page_title/1` driver function that we use in assertions to get the title of the page.

The assertion ignores whitespace when finding the title but the assertion only passes with equality. Thus, it doesn't match on a substring of the title.