### PR TITLE
Add `open_browser/1`

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -172,6 +172,12 @@ defmodule PhoenixTest do
   defdelegate submit_form(session, selector, data), to: Driver
 
   @doc """
+  Open the default browser to display current HTML of `session`.
+  """
+  defdelegate open_browser(session), to: Driver
+  defdelegate open_browser(session, open_fun), to: Driver
+
+  @doc """
   Assert helper to ensure an element with given CSS selector and `text` is
   present.
 

--- a/lib/phoenix_test/driver.ex
+++ b/lib/phoenix_test/driver.ex
@@ -8,4 +8,6 @@ defprotocol PhoenixTest.Driver do
   def click_button(session, selector, text)
   def fill_form(session, selector, form_data)
   def submit_form(session, selector, form_data)
+  def open_browser(session)
+  def open_browser(session, open_fun)
 end

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -156,6 +156,11 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
     phx_change != nil && phx_change != ""
   end
 
+  def open_browser(%{view: view} = session, open_fun \\ &Phoenix.LiveViewTest.open_browser/1) do
+    open_fun.(view)
+    session
+  end
+
   defp maybe_redirect({:error, {:redirect, %{to: path}}}, session) do
     PhoenixTest.visit(session.conn, path)
   end

--- a/lib/phoenix_test/open_browser.ex
+++ b/lib/phoenix_test/open_browser.ex
@@ -1,0 +1,76 @@
+defmodule PhoenixTest.OpenBrowser do
+  @moduledoc false
+
+  # This module contains private functionality ported over from
+  # `Phoenix.LiveViewTest` to make `open_browser` work with `Static` tests.
+
+  @doc """
+  Fully qualifies static assets paths so the browser can find them.
+  """
+  def prefix_static_paths(node, endpoint) do
+    static_path = static_path(endpoint)
+
+    case node do
+      # Remove script tags
+      {"script", _, _} -> nil
+      # Skip prefixing src attributes on anchor tags
+      {"a", _, _} = link -> link
+      {el, attrs, children} -> {el, maybe_prefix_static_path(attrs, static_path), children}
+      el -> el
+    end
+  end
+
+  defp static_path(endpoint) do
+    static_url = endpoint.config(:static_url) || []
+    priv_dir = :otp_app |> endpoint.config() |> Application.app_dir("priv")
+
+    if Keyword.get(static_url, :path) do
+      priv_dir
+    else
+      Path.join(priv_dir, "static")
+    end
+  end
+
+  defp maybe_prefix_static_path(attrs, nil), do: attrs
+
+  defp maybe_prefix_static_path(attrs, static_path) do
+    Enum.map(attrs, fn
+      {"src", path} -> {"src", prefix_static_path(path, static_path)}
+      {"href", path} -> {"href", prefix_static_path(path, static_path)}
+      attr -> attr
+    end)
+  end
+
+  defp prefix_static_path(<<"//" <> _::binary>> = url, _prefix), do: url
+
+  defp prefix_static_path(<<"/" <> _::binary>> = path, prefix) do
+    "file://#{Path.join([prefix, path])}"
+  end
+
+  defp prefix_static_path(url, _), do: url
+
+  @doc """
+  System agnostic function to open the default browser with the given `path`.
+
+  This is ripped verbatim from `Phoenix.LiveViewTest`.
+  """
+  def open_with_system_cmd(path) do
+    {cmd, args} =
+      case :os.type() do
+        {:win32, _} ->
+          {"cmd", ["/c", "start", path]}
+
+        {:unix, :darwin} ->
+          {"open", [path]}
+
+        {:unix, _} ->
+          if System.find_executable("cmd.exe") do
+            {"cmd.exe", ["/c", "start", path]}
+          else
+            {"xdg-open", [path]}
+          end
+      end
+
+    System.cmd(cmd, args)
+  end
+end

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -333,4 +333,21 @@ defmodule PhoenixTest.LiveTest do
       end
     end
   end
+
+  describe "open_browser" do
+    setup do
+      open_fun = fn view ->
+        assert %Phoenix.LiveViewTest.View{} = view
+      end
+
+      %{open_fun: open_fun}
+    end
+
+    test "opens the browser", %{conn: conn, open_fun: open_fun} do
+      conn
+      |> visit("/live/index")
+      |> open_browser(open_fun)
+      |> assert_has("h1", "LiveView main page")
+    end
+  end
 end

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -337,4 +337,35 @@ defmodule PhoenixTest.StaticTest do
                    end
     end
   end
+
+  describe "open_browser" do
+    setup do
+      open_fun = fn path ->
+        assert content = File.read!(path)
+
+        assert content =~
+                 ~r[<link rel="stylesheet" href="file:.*phoenix_test\/priv\/assets\/app\.css"\/>]
+
+        assert content =~ "<link rel=\"stylesheet\" href=\"//example.com/cool-styles.css\"/>"
+        assert content =~ "body { font-size: 12px; }"
+
+        assert content =~ ~r/<h1.*Main page/
+
+        refute content =~ "<script>"
+        refute content =~ "console.log(\"Hey, I'm some JavaScript!\")"
+        refute content =~ "</script>"
+
+        path
+      end
+
+      %{open_fun: open_fun}
+    end
+
+    test "opens the browser ", %{conn: conn, open_fun: open_fun} do
+      conn
+      |> visit("/page/index")
+      |> open_browser(open_fun)
+      |> assert_has("h1", "Main page")
+    end
+  end
 end

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -12,6 +12,14 @@ defmodule PhoenixTest.PageView do
     <html lang="en">
       <head>
         <title><%= assigns[:page_title] || "PhoenixTest is the best!" %></title>
+        <link rel="stylesheet" href="/assets/app.css">
+        <link rel="stylesheet" href="//example.com/cool-styles.css">
+        <script>
+          console.log("Hey, I'm some JavaScript!")
+        </script>
+        <style>
+          body { font-size: 12px; }
+        </style>
       </head>
       <body>
         <%= @inner_content %>

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -12,8 +12,8 @@ defmodule PhoenixTest.PageView do
     <html lang="en">
       <head>
         <title><%= assigns[:page_title] || "PhoenixTest is the best!" %></title>
-        <link rel="stylesheet" href="/assets/app.css">
-        <link rel="stylesheet" href="//example.com/cool-styles.css">
+        <link rel="stylesheet" href="/assets/app.css" />
+        <link rel="stylesheet" href="//example.com/cool-styles.css" />
         <script>
           console.log("Hey, I'm some JavaScript!")
         </script>


### PR DESCRIPTION
Hey German!

Me again.

First off I'd like to say that I'll be totally cool if you don't think this belongs in PhoenixTest, but I did a quick implementation and wanted to create the PR to get the discussion going.

So this introduces a `preview/1` function which is essentially a wrapper around `Phoenix.LiveViewTest.open_browser/1`.

## The problem with using `open_browser/1` directly

PhoenixTest's functions are all pipeable taking in a "session" as the first arg.  With `open_browser` essentially being `IO.inspect` for LiveViewTest, we want to be able to stick one in the middle of a pipeline.  We can't use `open_browser` for this since it takes a `Phoenix.LiveViewTest.View`.  Instead we have to change:

```elixir
conn
|> click_link("foo")
|> fill_form("form", foo: %{bar: "baz"})
|> click_button("Submit")
|> assert_has("Profit!")
```

into:

```elixir
sess =
  conn
  |> click_link("foo")

open_browser(sess.view)

sess
|> fill_form("form", foo: %{bar: "baz"})
|> click_button("Submit")
|> assert_has("Profit!")
```

and back just to "quickly" look at something in the browser.

I'm advocating for this to be a part of PhoenixTest because even though I just started using it yesterday, I'm already pretty in love with it and would prefer not to carry around my own `preview` function to all my projects (but I will if I have to 🙂).

In a nutshell, `preview` simply does the following:

```elixir
def preview(session) do
  Phoenix.LiveViewTest.open_browser(session.view)

  session
end
```

## Why call it `preview/1`?

Since this function can only work on LiveView tests, I wanted to come up with a more generic name in case some very rough equivalent could be implemented for controller tests.  As it stands, this implementation simply raises if given in a controller test.

**DECISION:** We're gonna call it `open_browser`.

## Problems with this PR

The tests I have now basically just ensure it raises in controller tests but otherwise takes a dummy code path to test the LiveView functionality.  In couldn't come up with a good regression test that was simple and un-intrusive.  I took inspiration from how `open_browser` is tested so that's why `preview/2` exists, but I realized it's really not the same thing.  I think something like Mox would be the proper way to go but I didn't want to introduce that without asking.

Anyway, I'm open to any and all feedback, this is a bit of a draft.  Thanks again for this project!