### PR TITLE
Improve doc and moduledoc

### DIFF
--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -1,5 +1,9 @@
 defmodule PhoenixTest.Assertions do
-  @moduledoc false
+  @moduledoc """
+  Module for asserting HTML content in Phoenix Framework tests.
+
+  This module provides functions for asserting the presence or absence of elements with specific selectors and text content in the rendered HTML within a test session.
+  """
 
   import ExUnit.Assertions
 
@@ -7,6 +11,20 @@ defmodule PhoenixTest.Assertions do
   alias PhoenixTest.Html
   alias PhoenixTest.Query
 
+  @doc """
+  Asserts that the rendered HTML content within the given session contains an element
+  matching the specified selector and text.
+
+  ## Parameters
+
+  - `session`: The test session.
+  - `selector`: The CSS selector to search for.
+  - `text`: The expected text content of the element.
+
+  ## Raises
+
+  Raises `AssertionError` if no element is found with the given selector and text.
+  """
   def assert_has(session, "title", text) do
     title = PhoenixTest.Driver.render_page_title(session)
 
@@ -51,6 +69,19 @@ defmodule PhoenixTest.Assertions do
     session
   end
 
+  @doc """
+  Asserts that the rendered HTML within the given session does not contain an element matching the specified selector and text.
+
+  ## Parameters
+
+  - `session`: The test session.
+  - `selector`: The CSS selector for the element.
+  - `text`: The text that the element is expected not to contain.
+
+  ## Raises
+
+  Raises `AssertionError` if an element matching the selector and text is found.
+  """
   def refute_has(session, "title", text) do
     title = PhoenixTest.Driver.render_page_title(session)
 

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -1,9 +1,5 @@
 defmodule PhoenixTest.Assertions do
-  @moduledoc """
-  Module for asserting HTML content in Phoenix Framework tests.
-
-  This module provides functions for asserting the presence or absence of elements with specific selectors and text content in the rendered HTML within a test session.
-  """
+  @moduledoc false
 
   import ExUnit.Assertions
 

--- a/lib/phoenix_test/html/form.ex
+++ b/lib/phoenix_test/html/form.ex
@@ -1,9 +1,5 @@
 defmodule PhoenixTest.Html.Form do
-  @moduledoc """
-  Utility module for building and validating HTML forms.
-
-  This module provides functions to build HTML form structures and validate form data.
-  """
+  @moduledoc false
 
   alias PhoenixTest.Html
 

--- a/lib/phoenix_test/html/form.ex
+++ b/lib/phoenix_test/html/form.ex
@@ -21,7 +21,6 @@ defmodule PhoenixTest.Html.Form do
   - `"fields"`: A list of maps representing form fields.
   - `"operative_method"`: A string representing the form's method, extracted from hidden input or defaulting to "get".
   """
-  @spec build(tuple()) :: map()
   def build({"form", attrs, fields}) do
     %{}
     |> Map.put("attributes", build_attributes(attrs))
@@ -93,7 +92,6 @@ defmodule PhoenixTest.Html.Form do
 
   Raises `ArgumentError` if the form data does not match the expected structure.
   """
-  @spec validate_form_data!(nil | maybe_improper_list() | map(), any()) :: :ok
   def validate_form_data!(form, form_data) do
     action = get_in(form, ["attributes", "action"])
     unless action, do: raise(ArgumentError, "Expected form to have an action but found none")
@@ -116,7 +114,6 @@ defmodule PhoenixTest.Html.Form do
 
   Raises `ArgumentError` if the form data does not match the expected structure.
   """
-  @spec validate_form_fields!(any(), any()) :: :ok
   def validate_form_fields!(form_fields, form_data) do
     form_data
     |> Enum.each(fn

--- a/lib/phoenix_test/html/form.ex
+++ b/lib/phoenix_test/html/form.ex
@@ -1,8 +1,31 @@
 defmodule PhoenixTest.Html.Form do
-  @moduledoc false
+  @moduledoc """
+  Utility module for building and validating HTML forms.
+
+  This module provides functions to build HTML form structures and validate form data.
+  """
 
   alias PhoenixTest.Html
 
+  @doc """
+  Builds an HTML form structure.
+
+  This function takes a tuple representation of a form and converts it into a map structure.
+
+  ## Parameters
+
+  - `{"form", attrs, fields}`: Tuple representing the form structure.
+    - `attrs`: A map containing form attributes (e.g., action, method).
+    - `fields`: A list of tuples representing form fields.
+
+  ## Returns
+
+  A map representing the HTML form structure with the following keys:
+  - `"attributes"`: A map containing form attributes.
+  - `"fields"`: A list of maps representing form fields.
+  - `"operative_method"`: A string representing the form's method, extracted from hidden input or defaulting to "get".
+  """
+  @spec build(tuple()) :: map()
   def build({"form", attrs, fields}) do
     %{}
     |> Map.put("attributes", build_attributes(attrs))
@@ -59,6 +82,22 @@ defmodule PhoenixTest.Html.Form do
     end
   end
 
+  @doc """
+  Validates the form data against the expected structure of a form.
+
+  This function ensures that the provided form data matches the structure expected by the form.
+  It checks for the presence of required fields and raises an error if the structure is not as expected.
+
+  ## Parameters
+
+  - `form`: A map representing the HTML form structure.
+  - `form_data`: A map containing the form data to be validated.
+
+  ## Raises
+
+  Raises `ArgumentError` if the form data does not match the expected structure.
+  """
+  @spec validate_form_data!(nil | maybe_improper_list() | map(), any()) :: :ok
   def validate_form_data!(form, form_data) do
     action = get_in(form, ["attributes", "action"])
     unless action, do: raise(ArgumentError, "Expected form to have an action but found none")
@@ -66,6 +105,22 @@ defmodule PhoenixTest.Html.Form do
     validate_form_fields!(form["fields"], form_data)
   end
 
+  @doc """
+  Validates the form fields against the provided form data.
+
+  This function checks if the provided form data matches the expected structure of the form fields.
+  It recursively validates nested maps within the form data and raises an error if the structure is not as expected.
+
+  ## Parameters
+
+  - `form_fields`: A list representing the HTML form fields.
+  - `form_data`: A map containing the form data to be validated.
+
+  ## Raises
+
+  Raises `ArgumentError` if the form data does not match the expected structure.
+  """
+  @spec validate_form_fields!(any(), any()) :: :ok
   def validate_form_fields!(form_fields, form_data) do
     form_data
     |> Enum.each(fn

--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -1,8 +1,26 @@
 defmodule PhoenixTest.Query do
-  @moduledoc false
+  @moduledoc """
+  Module for querying HTML content and extracting elements based on CSS selectors and text content.
+  """
 
   alias PhoenixTest.Html
 
+  @doc """
+  Finds the first element in the HTML content with the specified CSS selector.
+
+  ## Parameters
+
+  - `html`: The HTML content to search within.
+  - `selector`: The CSS selector for the element.
+
+  ## Returns
+
+  - `element`: If a the element is found.
+
+  ## Raises
+
+  Raises `ArgumentError` if no element is found with the given selector or if multiple elements are found.
+  """
   def find!(html, selector) do
     case find(html, selector) do
       :not_found ->
@@ -16,6 +34,23 @@ defmodule PhoenixTest.Query do
     end
   end
 
+  @doc """
+  Finds the first element in the HTML content with the specified CSS selector and text.
+
+  ## Parameters
+
+  - `html`: The HTML content to search within.
+  - `selector`: The CSS selector for the element.
+  - `text`: The text for the element.
+
+  ## Returns
+
+  - `element`: If a the element is found.
+
+  ## Raises
+
+  Raises `ArgumentError` if no element is found with the given selector or if multiple elements are found.
+  """
   def find!(html, selector, text) do
     case find(html, selector, text) do
       {:not_found, elements} ->
@@ -49,6 +84,21 @@ defmodule PhoenixTest.Query do
     end
   end
 
+  @doc """
+  Finds the first element in the HTML content with the specified CSS selector.
+
+  ## Parameters
+
+  - `html`: The HTML content to search within.
+  - `selector`: The CSS selector for the element.
+  - `text`: The text for the element.
+
+  ## Returns
+
+  - `{:found, element}`: If a single element is found.
+  - `:not_found`: If no elements are found.
+  - `{:found_many, elements}`: If more than one element is found.
+  """
   def find(html, selector) do
     html
     |> Html.parse()
@@ -65,6 +115,20 @@ defmodule PhoenixTest.Query do
     end
   end
 
+  @doc """
+  Finds the first element in the HTML content with the specified CSS selector and text.
+
+  ## Parameters
+
+  - `html`: The HTML content to search within.
+  - `selector`: The CSS selector for the element.
+
+  ## Returns
+
+  - `{:found, element}`: If a single element is found.
+  - `{:not_found, elements_matched_selector}`: If no elements are found.
+  - `{:found_many, elements}`: If more than one element is found.
+  """
   def find(html, selector, text) do
     elements_matched_selector =
       html
@@ -80,6 +144,23 @@ defmodule PhoenixTest.Query do
     end
   end
 
+  @doc """
+  Finds one element from the given list of selectors in the HTML content, raising an error if not found.
+
+  ## Parameters
+
+  - `html`: The HTML content to search within.
+  - `elements`: A list of tuples where each tuple contains a CSS selector and optional text content.
+
+  ## Returns
+
+  - `found_element`: The found element.
+  - `found_element`: In case a list of possible matches, returns the first one.
+
+  ## Raises
+
+  Raises `ArgumentError` if no element is found with the given selectors or if multiple elements are found.
+  """
   def find_one_of!(html, elements) do
     html
     |> find_one_of(elements)
@@ -114,6 +195,20 @@ defmodule PhoenixTest.Query do
     end
   end
 
+  @doc """
+  Finds one element from the given list of selectors in the HTML content.
+
+  ## Parameters
+
+  - `html`: The HTML content to search within.
+  - `elements`: A list of tuples where each tuple contains a CSS selector and optional text content.
+
+  ## Returns
+
+  - `found`: If a single element is found.
+  - `found`: If a many elements are found.
+  - `{:not_found, potential_matches}`: If no elements match the content criteria but elements match the selector.
+  """
   def find_one_of(html, elements) do
     results =
       elements

--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -1,7 +1,5 @@
 defmodule PhoenixTest.Query do
-  @moduledoc """
-  Module for querying HTML content and extracting elements based on CSS selectors and text content.
-  """
+  @moduledoc false
 
   alias PhoenixTest.Html
 


### PR DESCRIPTION
This PR adds a minimal `@doc` and `@moduledoc` for the following modules:

- Query
- Assertions
- Form

Overall the other modules seem to be well-covered with documentation on the file: `lib/phoenix_test.ex`

The initial conversation was tracked on #29 