### PR TITLE
Only document `open_browser/1`

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -183,6 +183,9 @@ defmodule PhoenixTest do
   |> submit_form("#user-form", name: "Aragorn")
   ```
   """
+  defdelegate open_browser(session), to: Driver
+
+  @doc false
   defdelegate open_browser(session, open_fun), to: Driver
 
   @doc """

--- a/lib/phoenix_test/driver.ex
+++ b/lib/phoenix_test/driver.ex
@@ -8,5 +8,6 @@ defprotocol PhoenixTest.Driver do
   def click_button(session, selector, text)
   def fill_form(session, selector, form_data)
   def submit_form(session, selector, form_data)
+  def open_browser(session)
   def open_browser(session, open_fun)
 end


### PR DESCRIPTION
This adds `@doc false` to `open_browser/2` (only used for tests) so that `mix docs` doesn't error out on us.