### PR TITLE
Relax Elixir version requirement to Elixir 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         otp: ['26.1.2']
-        elixir: ['1.16.0']
+        elixir: ['1.15.0', '1.16.0']
     steps:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1

--- a/mix.exs
+++ b/mix.exs
@@ -14,7 +14,7 @@ defmodule PhoenixTest.MixProject do
       app: :phoenix_test,
       version: @version,
       description: @description,
-      elixir: "~> 1.16",
+      elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       elixirc_paths: elixirc_paths(Mix.env()),


### PR DESCRIPTION
Closes #38 

Elixir 1.5 came out in June 2023. See the [announcement].

We should be able to support that.

[announcement]: https://elixir-lang.org/blog/2023/06/19/elixir-v1-15-0-released/