### PR TITLE
Follow redirects on `PhoenixTest.visit/2`

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -50,6 +50,10 @@ defmodule PhoenixTest do
       %{assigns: %{live_module: _}} = conn ->
         PhoenixTest.Live.build(conn)
 
+      %{status: 302} = conn ->
+        path = redirected_to(conn)
+        visit(conn, path)
+
       conn ->
         PhoenixTest.Static.build(conn)
     end

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -47,6 +47,18 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("h1", "LiveView main page")
     end
 
+    test "follows redirects", %{conn: conn} do
+      conn
+      |> visit("/live/redirect_on_mount/redirect")
+      |> assert_has("h1", "LiveView main page")
+    end
+
+    test "follows push redirects (push navigate)", %{conn: conn} do
+      conn
+      |> visit("/live/redirect_on_mount/push_navigate")
+      |> assert_has("h1", "LiveView main page")
+    end
+
     test "raises error if route doesn't exist", %{conn: conn} do
       assert_raise Phoenix.Router.NoRouteError, fn ->
         conn

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -35,6 +35,12 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("h1", "Main page")
     end
 
+    test "follows redirects", %{conn: conn} do
+      conn
+      |> visit("/page/redirect_to_static")
+      |> assert_has("h1", "Main page")
+    end
+
     test "raises error if route doesn't exist", %{conn: conn} do
       assert_raise Phoenix.Router.NoRouteError, fn ->
         conn

--- a/test/support/redirect_live.ex
+++ b/test/support/redirect_live.ex
@@ -1,0 +1,19 @@
+defmodule PhoenixTest.RedirectLive do
+  use Phoenix.LiveView
+
+  def render(assigns) do
+    ~H"""
+    <h1>You shouldn't see this</h1>
+    """
+  end
+
+  def mount(%{"redirect_type" => redirect_type}, _, socket) do
+    case redirect_type do
+      "push_navigate" ->
+        {:ok, push_redirect(socket, to: "/live/index")}
+
+      "redirect" ->
+        {:ok, redirect(socket, to: "/live/index")}
+    end
+  end
+end

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -29,9 +29,10 @@ defmodule PhoenixTest.Router do
     put "/page/update_record", PageController, :update
     delete "/page/delete_record", PageController, :delete
     get "/page/unauthorized", PageController, :unauthorized
-    get "/page/:page", PageController, :show
+    get "/page/redirect_to_static", PageController, :redirect_to_static
     post "/page/redirect_to_liveview", PageController, :redirect_to_liveview
     post "/page/redirect_to_static", PageController, :redirect_to_static
+    get "/page/:page", PageController, :show
 
     live_session :live_pages, root_layout: {PhoenixTest.PageView, :layout} do
       live "/live/index", IndexLive
@@ -39,5 +40,6 @@ defmodule PhoenixTest.Router do
     end
 
     live "/live/index_no_layout", IndexLive
+    live "/live/redirect_on_mount/:redirect_type", RedirectLive
   end
 end


### PR DESCRIPTION
Closes #41

What changed?
=============

Currently, `PhoenixTest.visit/2` doesn't follow redirects. That's a helpful feature to have since (a) other links, buttons, etc. follow redirects (so it's expected), and (b) for scenarios like testing authentication in an app (imagine testing that you visit a page and you are redirected to a different page).

This commit adds redirection and tests it from both the Static and Live implementations -- even though the implementation is the same for both. It all happens in `PhoenixTest.visit/2`.