### PR TITLE
Add `PhoenixTest.refute_has/2`

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -301,7 +301,7 @@ defmodule PhoenixTest do
   It'll raise an error if no elements are found, but it will _not_ raise if more
   than one matching element is found.
 
-  If you want to specify the conten of the element, use `assert_has/3`.
+  If you want to specify the content of the element, use `assert_has/3`.
   """
   defdelegate assert_has(session, selector), to: Assertions
 
@@ -313,6 +313,16 @@ defmodule PhoenixTest do
   than one matching element is found.
   """
   defdelegate assert_has(session, selector, text), to: Assertions
+
+  @doc """
+  Opposite of `assert_has/2` helper. Verifies that element with
+  given CSS selector is _not_ present.
+
+  It'll raise an error if any elements that match selector are found.
+
+  If you want to specify the content of the element, use `refute_has/3`.
+  """
+  defdelegate refute_has(session, selector), to: Assertions
 
   @doc """
   Opposite of `assert_has/3` helper. Verifies that element with

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -116,6 +116,53 @@ defmodule PhoenixTest.Assertions do
 
   Raises `AssertionError` if an element matching the selector and text is found.
   """
+  def refute_has(session, "title") do
+    title = PhoenixTest.Driver.render_page_title(session)
+
+    if is_nil(title) do
+      refute false
+    else
+      raise AssertionError,
+        message: """
+        Expected title not to be present but found: #{inspect(title)}
+        """
+    end
+
+    session
+  end
+
+  def refute_has(session, selector) do
+    session
+    |> PhoenixTest.Driver.render_html()
+    |> Query.find(selector)
+    |> case do
+      :not_found ->
+        refute false
+
+      {:found, element} ->
+        raise AssertionError,
+          message: """
+          Expected not to find an element.
+
+          But found an element with selector #{inspect(selector)}:
+
+          #{format_found_elements(element)}
+          """
+
+      {:found_many, elements} ->
+        raise AssertionError,
+          message: """
+          Expected not to find an element.
+
+          But found #{Enum.count(elements)} elements with selector #{inspect(selector)}:
+
+          #{format_found_elements(elements)}
+          """
+    end
+
+    session
+  end
+
   def refute_has(session, "title", text) do
     title = PhoenixTest.Driver.render_page_title(session)
 
@@ -127,6 +174,8 @@ defmodule PhoenixTest.Assertions do
     else
       refute false
     end
+
+    session
   end
 
   def refute_has(session, selector, text) do
@@ -153,6 +202,8 @@ defmodule PhoenixTest.Assertions do
           Expected not to find an element.
 
           But found #{Enum.count(elements)} elements with selector #{inspect(selector)} and text #{inspect(text)}:
+
+          #{format_found_elements(elements)}
           """
     end
 

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -202,17 +202,92 @@ defmodule PhoenixTest.AssertionsTest do
     end
   end
 
+  describe "refute_has/2" do
+    test "succeeds if no element is found with CSS selector (Static)", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> refute_has("#some-invalid-id")
+      |> refute_has("[data-role='invalid-role']")
+    end
+
+    test "succeeds if no element is found with CSS selector (Live)", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> refute_has("#some-invalid-id")
+      |> refute_has("[data-role='invalid-role']")
+    end
+
+    test "can refute presence of title (Static)", %{conn: conn} do
+      conn
+      |> visit("/page/index_no_layout")
+      |> refute_has("title")
+      |> refute_has("#something-else-to-test-pipe")
+    end
+
+    test "raises if element is found", %{conn: conn} do
+      msg =
+        """
+        Expected not to find an element.
+
+        But found an element with selector "h1":
+
+        <h1 id="title" class="title" data-role="title">
+          Main page
+        </h1>
+        """
+        |> ignore_whitespace()
+
+      assert_raise AssertionError, msg, fn ->
+        conn
+        |> visit("/page/index")
+        |> refute_has("h1")
+      end
+    end
+
+    test "raises if title is found", %{conn: conn} do
+      msg =
+        """
+        Expected title not to be present but found: "PhoenixTest is the best!"
+        """
+        |> ignore_whitespace()
+
+      assert_raise AssertionError, msg, fn ->
+        conn
+        |> visit("/page/index")
+        |> refute_has("title")
+      end
+    end
+
+    test "raises an error if multiple elements are found", %{conn: conn} do
+      conn = visit(conn, "/page/index")
+
+      msg =
+        """
+        Expected not to find an element.
+
+        But found 2 elements with selector ".multiple_links":
+        """
+        |> ignore_whitespace()
+
+      assert_raise AssertionError, msg, fn ->
+        conn |> refute_has(".multiple_links")
+      end
+    end
+  end
+
   describe "refute_has/3" do
     test "can be used to refute on page title (Static)", %{conn: conn} do
       conn
       |> visit("/page/index")
       |> refute_has("title", "Not the title")
+      |> refute_has("title", "Not this title either")
     end
 
     test "can be used to refute on page title (Live)", %{conn: conn} do
       conn
       |> visit("/live/index")
       |> refute_has("title", "Not the title")
+      |> refute_has("title", "Not this title either")
     end
 
     test "raises if title matches value (Static)", %{conn: conn} do
@@ -289,6 +364,14 @@ defmodule PhoenixTest.AssertionsTest do
         Expected not to find an element.
 
         But found 2 elements with selector ".multiple_links" and text "Multiple links":
+
+        <a class="multiple_links" href="/page/page_3">
+          Multiple links
+        </a>
+
+        <a class="multiple_links" href="/page/page_4">
+          Multiple links
+        </a>
         """
         |> ignore_whitespace()
 

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -18,10 +18,6 @@ defmodule PhoenixTest.Router do
     plug(:fetch_live_flash)
   end
 
-  pipeline :bad_layout do
-    plug(:put_root_layout, {UnknownView, :unknown_template})
-  end
-
   scope "/", PhoenixTest do
     pipe_through([:browser])
 


### PR DESCRIPTION
Closes #43

What changed?
=============

In commit 3756a47, we added a `PhoenixTest.assert_has/2` helper because there are cases when we want to assert an element is present WITHOUT specifying the text (e.g. an input where the `value=` attribute is what the user sees).

We now introduce a similar `refute_has/2` helper that doesn't require passing text for the same reasons.

Note: we also remove an unused pipeline in the test router.