### PR TITLE
Do not assume submit button after fill_form

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -142,12 +142,12 @@ defmodule PhoenixTest.LiveTest do
       assert_raise ArgumentError, ~r/does not have phx-click attribute/, fn ->
         conn
         |> visit("/live/index")
-        |> click_button("Save email")
+        |> click_button("Submit Invalid Form")
       end
     end
 
     test "raises an error if active form but can't find button", %{conn: conn} do
-      assert_raise ArgumentError, ~r/Could not find an element with given selector/, fn ->
+      assert_raise ArgumentError, ~r/none matched the text filter "No button"/, fn ->
         conn
         |> visit("/live/index")
         |> fill_form("#no-phx-change-form", name: "Legolas")
@@ -193,7 +193,7 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> visit("/live/index")
       |> fill_in("Email", with: "someone@example.com")
-      |> click_button("Save email")
+      |> click_button("Save")
       |> assert_has("#form-data", "email: someone@example.com")
     end
   end
@@ -284,6 +284,14 @@ defmodule PhoenixTest.LiveTest do
       |> fill_form("#email-form", email: "some@example.com")
       |> click_button("Save")
       |> assert_has("#form-data", "email: some@example.com")
+    end
+
+    test "can handle clicking button that does not submit form after fill_form", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_form("#email-form", email: "some@example.com")
+      |> click_button("Reset")
+      |> refute_has("#form-data", "email: some@example.com")
     end
 
     test "can handle forms with inputs, checkboxes, selects, textboxes", %{conn: conn} do

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -209,7 +209,9 @@ defmodule PhoenixTest.StaticTest do
     end
 
     test "raises an error when there are no buttons on page", %{conn: conn} do
-      assert_raise ArgumentError, ~r/Could not find an element with given selector/, fn ->
+      msg = ~r/Could not find element with selector "button" and text "Show tab"/
+
+      assert_raise ArgumentError, msg, fn ->
         conn
         |> visit("/page/page_2")
         |> click_button("Show tab")
@@ -217,7 +219,9 @@ defmodule PhoenixTest.StaticTest do
     end
 
     test "raises an error if can't find button", %{conn: conn} do
-      assert_raise ArgumentError, ~r/Could not find an element with given selector/, fn ->
+      msg = ~r/Could not find element with selector "button" and text "No button"/
+
+      assert_raise ArgumentError, msg, fn ->
         conn
         |> visit("/page/index")
         |> click_button("No button")
@@ -303,8 +307,16 @@ defmodule PhoenixTest.StaticTest do
       conn
       |> visit("/page/index")
       |> fill_form("#email-form", email: "sample@example.com")
-      |> click_button("#email-form", "Save")
+      |> click_button("Save")
       |> assert_has("#form-data", "email: sample@example.com")
+    end
+
+    test "can handle clicking button that does not submit form after fill_form", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> fill_form("#email-form", email: "some@example.com")
+      |> click_button("Delete record")
+      |> refute_has("#form-data", "email: some@example.com")
     end
 
     test "can submit nested forms", %{conn: conn} do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -29,8 +29,9 @@ defmodule PhoenixTest.IndexLive do
     <form id="email-form" phx-change="validate-email" phx-submit="save-form">
       <label for="email">Email</label>
       <input id="email" name="email" value={assigns[:email]} />
-      <button type="submit">Save email</button>
+      <button>Save</button>
     </form>
+    <button phx-click="reset-email-form">Reset</button>
 
     <div :if={@form_saved} id="form-data">
       <%= for {key, value} <- @form_data do %>
@@ -74,6 +75,8 @@ defmodule PhoenixTest.IndexLive do
       <label for="notes">Notes</label>
       <textarea id="notes" name="notes" rows="5" cols="33">
       </textarea>
+
+      <button>Save</button>
     </form>
 
     <form id="redirect-form" phx-submit="save-redirect-form">
@@ -153,6 +156,12 @@ defmodule PhoenixTest.IndexLive do
 
   def handle_event("save-redirect-form-to-static", _, socket) do
     {:noreply, redirect(socket, to: "/page/index")}
+  end
+
+  def handle_event("reset-email-form", _, socket) do
+    socket
+    |> assign(:email, nil)
+    |> then(&{:noreply, &1})
   end
 
   def handle_event("validate-email", %{"email" => email}, socket) do

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -83,7 +83,7 @@ defmodule PhoenixTest.PageView do
     <form action="/page/create_record" method="post" id="email-form">
       <label for="email">Email</label>
       <input type="text" id="email" name="email" />
-      <button>Save</button>
+      <input type="submit" value="Save" />
     </form>
 
     <form id="update-form" action="/page/update_record" method="post">
@@ -133,6 +133,8 @@ defmodule PhoenixTest.PageView do
         <label for="member_of_fellowship">Member of fellowship</label>
         <input type="checkbox" name="member_of_fellowship" />
       </div>
+
+      <button>Save</button>
     </form>
 
     <form id="redirect-to-liveview-form" method="post" action="/page/redirect_to_liveview">


### PR DESCRIPTION
What changed?
=============

Our implementation of `click_button` assumes a little too much when it's preceded by a `fill_form` (meaning we have an "active form").

We assume that if you're clicking a button you're trying to submit the active form. But it could be equally true that we're cancelling the form (or as our Live test shows, that you're resetting the form, or in the case of our Static test that you're just clicking a completely different button).

So... we have to make our errors a little less helpful but allow for a better experience.

Instead of validating that the button is a submit button and raising if it isn't (which is actually confusing if you're trying to, say, cancel a form submission -- "of course it's not submit button! We're cancelling the form!"), we now check if the button you're clicking is a submit button for the form. If it isn't, we follow down the regular button click path -- assuming `phx-click` in LiveView and a single button form submission in Static.