### PR TITLE
Add `count` on `assert_has/2` and `refute_has/2`

### DIFF
--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -38,29 +38,13 @@ defmodule PhoenixTest.Assertions do
   end
 
   def assert_has(session, selector) when is_binary(selector) do
-    session
-    |> PhoenixTest.Driver.render_html()
-    |> Query.find(selector)
-    |> case do
-      {:found, _found} ->
-        assert true
-
-      {:found_many, _found} ->
-        assert true
-
-      :not_found ->
-        raise AssertionError,
-          message: """
-          Could not find any elements with selector #{inspect(selector)}.
-          """
-    end
-
-    session
+    assert_has(session, selector, count: :any)
   end
 
   def assert_has(session, selector_builder) do
     html = PhoenixTest.Driver.render_html(session)
     selector = Selectors.compile(selector_builder, html)
+
     assert_has(session, selector)
   end
 
@@ -79,7 +63,7 @@ defmodule PhoenixTest.Assertions do
     session
   end
 
-  def assert_has(session, selector, text) do
+  def assert_has(session, selector, text) when is_binary(text) do
     session
     |> PhoenixTest.Driver.render_html()
     |> Query.find(selector, text)
@@ -105,6 +89,49 @@ defmodule PhoenixTest.Assertions do
 
           #{format_found_elements(elements_matched_selector)}
           """
+    end
+
+    session
+  end
+
+  def assert_has(session, selector, opts) when is_list(opts) do
+    expected_count = Keyword.get(opts, :count, :any)
+
+    session
+    |> PhoenixTest.Driver.render_html()
+    |> Query.find(selector)
+    |> case do
+      :not_found ->
+        raise AssertionError,
+          message: """
+          Could not find any elements with selector #{inspect(selector)}.
+          """
+
+      {:found, found} ->
+        if expected_count in [:any, 1] do
+          assert true
+        else
+          raise AssertionError,
+            message: """
+            Expected #{expected_count} elements with #{inspect(selector)} but found 1 instead:
+
+            #{format_found_elements(found)}
+            """
+        end
+
+      {:found_many, found} ->
+        count = Enum.count(found)
+
+        if expected_count in [:any, count] do
+          assert true
+        else
+          raise AssertionError,
+            message: """
+            Expected #{expected_count} elements with #{inspect(selector)} but found #{count} instead:
+
+            #{format_found_elements(found)}
+            """
+        end
     end
 
     session
@@ -139,35 +166,7 @@ defmodule PhoenixTest.Assertions do
   end
 
   def refute_has(session, selector) when is_binary(selector) do
-    session
-    |> PhoenixTest.Driver.render_html()
-    |> Query.find(selector)
-    |> case do
-      :not_found ->
-        refute false
-
-      {:found, element} ->
-        raise AssertionError,
-          message: """
-          Expected not to find an element.
-
-          But found an element with selector #{inspect(selector)}:
-
-          #{format_found_elements(element)}
-          """
-
-      {:found_many, elements} ->
-        raise AssertionError,
-          message: """
-          Expected not to find an element.
-
-          But found #{Enum.count(elements)} elements with selector #{inspect(selector)}:
-
-          #{format_found_elements(elements)}
-          """
-    end
-
-    session
+    refute_has(session, selector, count: :any)
   end
 
   def refute_has(session, "title", text) do
@@ -185,7 +184,7 @@ defmodule PhoenixTest.Assertions do
     session
   end
 
-  def refute_has(session, selector, text) do
+  def refute_has(session, selector, text) when is_binary(text) do
     session
     |> PhoenixTest.Driver.render_html()
     |> Query.find(selector, text)
@@ -212,6 +211,50 @@ defmodule PhoenixTest.Assertions do
 
           #{format_found_elements(elements)}
           """
+    end
+
+    session
+  end
+
+  def refute_has(session, selector, opts) when is_list(opts) do
+    refute_count = Keyword.get(opts, :count, :any)
+
+    session
+    |> PhoenixTest.Driver.render_html()
+    |> Query.find(selector)
+    |> case do
+      :not_found ->
+        refute false
+
+      {:found, element} ->
+        if refute_count in [:any, 1] do
+          raise AssertionError,
+            message: """
+            Expected not to find any elements with selector #{inspect(selector)}.
+
+            But found:
+
+            #{format_found_elements(element)}
+            """
+        else
+          refute false
+        end
+
+      {:found_many, elements} ->
+        count = Enum.count(elements)
+
+        if refute_count in [:any, count] do
+          raise AssertionError,
+            message: """
+            Expected not to find #{refute_count} elements with selector #{inspect(selector)}.
+
+            But found:
+
+            #{format_found_elements(elements)}
+            """
+        else
+          refute false
+        end
     end
 
     session

--- a/lib/phoenix_test/selectors.ex
+++ b/lib/phoenix_test/selectors.ex
@@ -14,8 +14,9 @@ defmodule PhoenixTest.Selectors do
 
   def compile({:input, attrs}, html) do
     {label, attrs} = Map.pop(attrs, :label)
+
     element = Query.find_by_label!(html, label)
-    label_for = Html.attribute(element, "for")
+    id = Html.attribute(element, "id")
 
     existing_attrs =
       Enum.filter(attrs, fn {_k, v} -> v != nil end)
@@ -23,6 +24,6 @@ defmodule PhoenixTest.Selectors do
         acc <> "[#{k}=#{inspect(v)}]"
       end)
 
-    "input##{label_for}" <> existing_attrs
+    "input##{id}" <> existing_attrs
   end
 end


### PR DESCRIPTION
We add a `count:` option to `assert_has/2` and `refute_has/2` (making them 3-arity functions)

That allows people to test things like the exact number of elements in a list (e.g. with `.posts`):

```elixir
|> assert_has(".posts", count: 3)
```

Or refuting an exact number of elements:

```elixir
|> refute_has(".posts", count: 2)
```

(i.e. refute that there are 2 posts. 1 post is fine. More than 2 is fine).

What about `text` functions?
----------------------------

For now, we leave the other 3-arity assert and refute functions as they are -- meaning they take the `text` as the third argument.

Before we officially roll out this `count:` option, it would be nice to bring the text functions inline, but rather than turning them into 4-arity functions, we should make the text itself an option.

In other words, rather than having this:

```elixir
|> assert_has(".posts", "hello", count: 3)
```

Maybe we should have:

```elixir
|> assert_has(".posts", text: "hello", count: 3)
```

Maybe when we try to implement that,  we'll figure out it'll be better to just keep the `text` as its own argument, but moving it to an option is a decent idea for now.