### PR TITLE
Add `at` to assert against position

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -334,10 +334,12 @@ defmodule PhoenixTest do
   - `exact`: by default `assert_has/3` will perform a substring match (e.g. `a
   =~ b`). That makes it easier to assert text within HTML elements that also
   contain other HTML elements. But sometimes we want to assert the exact text is
-  present. For that, use `exact: true`.
+  present. For that, use `exact: true`. (defaults to `false`)
 
   - `count`: the number of items you expect to match CSS selector (and `text` if
   provided)
+
+  - `at`: the element to be asserted against
 
   ## Examples
 
@@ -355,6 +357,9 @@ defmodule PhoenixTest do
 
   # assert there are two elements with class "posts" and text "Hello"
   assert_has(session, ".posts", text: "Hello", count: 2)
+
+  # assert the second element in the list of ".posts" has text "Hello"
+  assert_has(session, ".posts", at: 2, text: "Hello")
   ```
   """
   defdelegate assert_has(session, selector, opts), to: Assertions
@@ -397,6 +402,8 @@ defmodule PhoenixTest do
   - `count`: the number of items you're expecting _should not_ match the CSS
   selector (and `text` if provided)
 
+  - `at`: the element to be refuted against
+
   ## Examples
 
   ```elixir
@@ -411,6 +418,9 @@ defmodule PhoenixTest do
 
   # refute there are two elements with class "posts" and text "Hello"
   refute_has(session, ".posts", text: "Hello", count: 2)
+
+  # refute the second element with class "posts" has text "Hello"
+  refute_has(session, ".posts", at: 2, text: "Hello")
   ```
   """
   defdelegate refute_has(session, selector, opts), to: Assertions

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -117,7 +117,7 @@ defmodule PhoenixTest.AssertionsTest do
         """
         Could not find any elements with selector "h1" and text "Super page".
 
-        Found other elements matching the selector "h1":
+        Found these elements matching the selector "h1":
 
         <h1 id="title" class="title" data-role="title">
           Main page
@@ -193,7 +193,7 @@ defmodule PhoenixTest.AssertionsTest do
         """
         Could not find any elements with selector "#multiple-items" and text "Frodo".
 
-        Found other elements matching the selector "#multiple-items":
+        Found these elements matching the selector "#multiple-items":
 
         <ul id="multiple-items">
           <li>
@@ -267,7 +267,7 @@ defmodule PhoenixTest.AssertionsTest do
         """
         Could not find any elements with selector "h1" and text "Main".
 
-        Found other elements matching the selector "h1":
+        Found these elements matching the selector "h1":
 
         <h1 id="title" class="title" data-role="title">
           Main page
@@ -279,6 +279,26 @@ defmodule PhoenixTest.AssertionsTest do
         conn
         |> visit("/page/index")
         |> assert_has("h1", text: "Main", exact: true)
+      end
+    end
+
+    test "accepts an `at` option to assert on a specific element", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> assert_has("#multiple-items li", at: 2, text: "Legolas")
+    end
+
+    test "raises if it cannot find element at `at` position", %{conn: conn} do
+      msg =
+        """
+        Could not find any elements with selector "#multiple-items li" and text "Aragorn" at position 2
+        """
+        |> ignore_whitespace()
+
+      assert_raise AssertionError, msg, fn ->
+        conn
+        |> visit("/page/index")
+        |> assert_has("#multiple-items li", at: 2, text: "Aragorn")
       end
     end
   end
@@ -523,6 +543,32 @@ defmodule PhoenixTest.AssertionsTest do
         conn
         |> visit("/page/index")
         |> refute_has("h1", text: "Main", exact: false)
+      end
+    end
+
+    test "accepts an `at` option to refute on a specific element", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> refute_has("#multiple-items li", at: 2, text: "Aragorn")
+    end
+
+    test "raises if it finds element at `at` position", %{conn: conn} do
+      msg =
+        """
+        Expected not to find any elements with selector "#multiple-items li" and text "Legolas" at position 2
+
+        But found 1:
+
+        <li>
+          Legolas
+        </li>
+        """
+        |> ignore_whitespace()
+
+      assert_raise AssertionError, msg, fn ->
+        conn
+        |> visit("/page/index")
+        |> refute_has("#multiple-items li", at: 2, text: "Legolas")
       end
     end
   end

--- a/test/phoenix_test/query_test.exs
+++ b/test/phoenix_test/query_test.exs
@@ -165,6 +165,17 @@ defmodule PhoenixTest.QueryTest do
       assert {"div", [{"class", "greeting"}], ["Hello"]} = el2
     end
 
+    test "only returns element `at` (1-based index) if requested" do
+      html = """
+      <div id="1" class="greeting">Hello</div>
+      <div id="2" class="greeting">Hello</div>
+      """
+
+      {:found, el} = Query.find(html, ".greeting", "Hello", at: 2)
+
+      assert {"div", [{"id", "2"}, _], ["Hello"]} = el
+    end
+
     test "finds element with text if multiple match CSS selector" do
       html = """
       <div class="greeting">Hello</div>


### PR DESCRIPTION
Resolves https://github.com/germsvel/phoenix_test/issues/27

What changed?
=============

We add an `at` option to `assert_has/3` and `refute_has/3` to assert against a specific position.

This is helpful if, for example, you want to assert what is the text of the second element in a list:

```elixir
assert_has("li", at: 2, text: "Hello world")
```