### PR TITLE
Follow multiple redirects in Live

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -236,7 +236,12 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   end
 
   defp maybe_redirect({:error, {:live_redirect, _}} = result, session) do
-    {:ok, view, _} = follow_redirect(result, session.conn)
+    result
+    |> follow_redirect(session.conn)
+    |> maybe_redirect(session)
+  end
+
+  defp maybe_redirect({:ok, view, _}, session) do
     %{session | view: view}
   end
 

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -76,6 +76,13 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("h1", text: "LiveView page 2")
     end
 
+    test "follows navigation that subsequently redirect", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_link("Navigate (and redirect back) link")
+      |> assert_has("h1", text: "LiveView main page")
+    end
+
     test "accepts click_link with selector", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -57,6 +57,13 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("h1", text: "Page 2")
     end
 
+    test "follows link that subsequently redirects", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> click_link("Navigate away and redirect back")
+      |> assert_has("h1", text: "Main page")
+    end
+
     test "accepts selector for link", %{conn: conn} do
       conn
       |> visit("/page/index")

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -12,6 +12,8 @@ defmodule PhoenixTest.IndexLive do
     <.link class="multiple_links" href="/live/page_3">Multiple links</.link>
     <.link class="multiple_links" href="/live/page_4">Multiple links</.link>
 
+    <.link navigate="/live/page_2?redirect_to=/live/index">Navigate (and redirect back) link</.link>
+
     <h2 :if={@details}>LiveView main page details</h2>
 
     <button phx-click="change-page-title">Change page title</button>

--- a/test/support/page_2_live.ex
+++ b/test/support/page_2_live.ex
@@ -6,4 +6,12 @@ defmodule PhoenixTest.Page2Live do
     <h1>LiveView page 2</h1>
     """
   end
+
+  def mount(%{"redirect_to" => path}, _, socket) do
+    {:ok, push_navigate(socket, to: path)}
+  end
+
+  def mount(_, _, socket) do
+    {:ok, socket}
+  end
 end

--- a/test/support/page_controller.ex
+++ b/test/support/page_controller.ex
@@ -9,6 +9,11 @@ defmodule PhoenixTest.PageController do
     |> render("index.html")
   end
 
+  def show(conn, %{"redirect_to" => path}) do
+    conn
+    |> redirect(to: path)
+  end
+
   def show(conn, %{"page" => page}) do
     conn
     |> render(page <> ".html")

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -34,6 +34,8 @@ defmodule PhoenixTest.PageView do
 
     <a href="/page/page_2">Page 2</a>
 
+    <a href="/page/no_page?redirect_to=/page/index">Navigate away and redirect back</a>
+
     <a class="multiple_links" href="/page/page_3">Multiple links</a>
     <a class="multiple_links" href="/page/page_4">Multiple links</a>
 


### PR DESCRIPTION
Resolves https://github.com/germsvel/phoenix_test/issues/55

What changed?
============

When we `click_link` we follow redirects. But in `Live`, we only follow the redirect once. This commit updates the code so that we continue following them until we get a mounted LiveView or an HTML response.

The `Static` implementation already followed links more than once, but we add a test here to keep the implementation tests at the same level.