### PR TITLE
Update assert_has examples to new API

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ test "admin can create a user", %{conn: conn} do
   |> click_link("Users")
   |> fill_form("#user-form", name: "Aragorn", email: "aragorn@dunedain.com")
   |> click_button("Create")
-  |> assert_has(".user", "Aragorn")
+  |> assert_has(".user", text: "Aragorn")
 end
 ```
 
@@ -122,7 +122,7 @@ defmodule MyAppWeb.AdminCanCreateUserTest do
     |> click_link("Users")
     |> fill_form("#user-form", name: "Aragorn", email: "aragorn@dunedain.com")
     |> click_button("Create")
-    |> assert_has(".user", "Aragorn")
+    |> assert_has(".user", text: "Aragorn")
   end
 ```
 

--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -19,7 +19,7 @@ defmodule PhoenixTest do
       |> click_link("Users")
       |> fill_form("#user-form", name: "Aragorn", email: "aragorn@dunedan.com")
       |> click_button("Create")
-      |> assert_has(".user", "Aragorn")
+      |> assert_has(".user", text: "Aragorn")
     end
     ```
 


### PR DESCRIPTION
There were a few instances of example code that used the deprecated version of `assert_has/3`. This updates those to match the new API.