### PR TITLE
Fix assert_has/refute_has title matching exactly

### DIFF
--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -54,10 +54,13 @@ defmodule PhoenixTest.Assertions do
     assert_has(session, "title", text: text)
   end
 
-  def assert_has(session, "title", text: text) do
+  def assert_has(session, "title", opts) do
+    text = Keyword.fetch!(opts, :text)
+    exact = Keyword.get(opts, :exact, false)
     title = PhoenixTest.Driver.render_page_title(session)
+    matches? = if exact, do: title == text, else: title =~ text
 
-    if title == text do
+    if matches? do
       assert true
     else
       raise AssertionError,
@@ -148,10 +151,13 @@ defmodule PhoenixTest.Assertions do
     refute_has(session, "title", text: text)
   end
 
-  def refute_has(session, "title", text: text) do
+  def refute_has(session, "title", opts) do
+    text = Keyword.fetch!(opts, :text)
+    exact = Keyword.get(opts, :exact, false)
     title = PhoenixTest.Driver.render_page_title(session)
+    matches? = if exact, do: title == text, else: title =~ text
 
-    if title == text do
+    if matches? do
       raise AssertionError,
         message: """
         Expected title not to be #{inspect(text)}

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -142,6 +142,12 @@ defmodule PhoenixTest.AssertionsTest do
       |> assert_has("title", text: "PhoenixTest is the best!")
     end
 
+    test "can assert title's exactness", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> assert_has("title", text: "PhoenixTest is the best!", exact: true)
+    end
+
     test "raises if title does not match expected value (Static)", %{conn: conn} do
       msg =
         """
@@ -170,7 +176,8 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
-    test "raises if title is contained but is not exactly the same as expected", %{conn: conn} do
+    test "raises if title is contained but is not exactly the same as expected (with exact=true)",
+         %{conn: conn} do
       msg =
         """
         Expected title to be "PhoenixTest" but got "PhoenixTest is the best!"
@@ -180,7 +187,7 @@ defmodule PhoenixTest.AssertionsTest do
       assert_raise AssertionError, msg, fn ->
         conn
         |> visit("/page/index")
-        |> assert_has("title", text: "PhoenixTest")
+        |> assert_has("title", text: "PhoenixTest", exact: true)
       end
     end
 
@@ -428,6 +435,12 @@ defmodule PhoenixTest.AssertionsTest do
       |> visit("/live/index")
       |> refute_has("title", text: "Not the title")
       |> refute_has("title", text: "Not this title either")
+    end
+
+    test "can be used to refute page title's exactness", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> refute_has("title", text: "PhoenixTest is the", exact: true)
     end
 
     test "raises if title matches value (Static)", %{conn: conn} do


### PR DESCRIPTION
Resolves https://github.com/germsvel/phoenix_test/issues/64

What changed?
============

Our `assert_has/3` and `refute_has/3` helpers with `"title"` behave differently from the rest of our assertion helpers.

By default our other assertion helpers perform a match (`=~`) operation. Our "title" assertion performs an equality (`==`) operation.

In addition to being different from the rest, it's annoying because we typically render the title with a `<.live_title>` tag which has newlines and spaces.

We fix that in this commit and allow people to pass `exact: true` to match exactly.