### PR TITLE
assert_path/refute_path partially handle Live Navigation

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -444,6 +444,10 @@ defmodule PhoenixTest do
   Assert helper to verify current request path. Takes an optional `query_params`
   map.
 
+  > ### Limited live patch implementation {: .warning}
+  >
+  > The current `assert_path` implementation doesn't support live patches.
+
   ## Examples
 
   ```elixir
@@ -468,6 +472,10 @@ defmodule PhoenixTest do
   @doc """
   Verifies current request path is NOT the one provided. Takes an optional
   `query_params` map for more specificity.
+
+  > ### Limited live patch implementation {: .warning}
+  >
+  > The current `refute_path` implementation doesn't support live patches.
 
   ## Examples
 

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -209,13 +209,13 @@ defmodule PhoenixTest.Assertions do
   end
 
   def assert_path(session, path) do
-    request_path = session.conn.request_path
+    current_path = session.current_path
 
-    if request_path == path do
+    if current_path == path do
       assert true
     else
       msg = """
-      Expected path to be #{inspect(path)} but got #{inspect(request_path)}
+      Expected path to be #{inspect(path)} but got #{inspect(current_path)}
       """
 
       raise AssertionError, msg

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -7,11 +7,11 @@ defmodule PhoenixTest.Live do
 
   alias PhoenixTest.ActiveForm
 
-  defstruct view: nil, conn: nil, active_form: ActiveForm.new(), within: :none
+  defstruct view: nil, conn: nil, active_form: ActiveForm.new(), within: :none, current_path: nil
 
   def build(conn) do
     {:ok, view, _html} = live(conn)
-    %__MODULE__{view: view, conn: conn}
+    %__MODULE__{view: view, conn: conn, current_path: conn.request_path}
   end
 end
 
@@ -266,7 +266,9 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
     PhoenixTest.visit(session.conn, path)
   end
 
-  defp maybe_redirect({:error, {:live_redirect, _}} = result, session) do
+  defp maybe_redirect({:error, {:live_redirect, %{to: path}}} = result, session) do
+    session = %{session | current_path: path}
+
     result
     |> follow_redirect(session.conn)
     |> maybe_redirect(session)

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -3,10 +3,10 @@ defmodule PhoenixTest.Static do
 
   alias PhoenixTest.ActiveForm
 
-  defstruct conn: nil, active_form: ActiveForm.new(), within: :none
+  defstruct conn: nil, active_form: ActiveForm.new(), within: :none, current_path: nil
 
   def build(conn) do
-    %__MODULE__{conn: conn}
+    %__MODULE__{conn: conn, current_path: conn.request_path}
   end
 end
 

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -587,10 +587,30 @@ defmodule PhoenixTest.AssertionsTest do
   end
 
   describe "assert_path" do
-    test "asserts that the given path is the current path", %{conn: conn} do
+    test "asserts that the given path is the current path (Static)", %{conn: conn} do
       conn
       |> visit("/page/index")
       |> assert_path("/page/index")
+    end
+
+    test "asserts current path when following links", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> click_link("Page 2")
+      |> assert_path("/page/page_2")
+    end
+
+    test "asserts that the given path is the current path (Live)", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> assert_path("/live/index")
+    end
+
+    test "asserts correct path with Live navigation", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_link("Navigate link")
+      |> assert_path("/live/page_2")
     end
 
     test "asserts query params are the same", %{conn: conn} do


### PR DESCRIPTION
Partially handles https://github.com/germsvel/phoenix_test/issues/62

What changed?
=============

We improve our `assert_path` and `refute_path` implementation to partially handle live navigation. For now, we handle `<.link navigate>` options but we do not support `<.link patch>`

Patching is done at the LiveView process level, and we need to figure out how to best handle that.

For now, we release this fix to improve the experience, but we include a warning in the docs that the helpers do not support patching.