### PR TITLE
Failing test for hidden input accompanying checkbox

### DIFF
--- a/test/phoenix_test/form_test.exs
+++ b/test/phoenix_test/form_test.exs
@@ -62,6 +62,36 @@ defmodule PhoenixTest.FormTest do
              } = form.form_data
     end
 
+    test "ignores hidden value for checkbox when checked" do
+      html = """
+      <form id="form">
+        <input name="checkbox" type="hidden" value="unchecked" />
+        <input name="checkbox" type="checkbox" value="checked" checked />
+      </form>
+      """
+
+      form = Form.find!(html, "form")
+
+      assert %{
+               "checkbox" => "checked"
+             } = form.form_data
+    end
+
+    test "uses hidden value for checkbox when unchecked" do
+      html = """
+      <form id="form">
+        <input name="checkbox" type="hidden" value="unchecked" />
+        <input name="checkbox" type="checkbox" value="checked" />
+      </form>
+      """
+
+      form = Form.find!(html, "form")
+
+      assert %{
+               "checkbox" => "unchecked"
+             } = form.form_data
+    end
+
     test "does not include disabled inputs in form_data" do
       html = """
       <form id="form">


### PR DESCRIPTION
Hi @germsvel, i noticed an issue with some of my tests when i updated phoenix test to 0.2.11.

When submitting a form with a checkbox that has an accompanying hidden input (to populate the params when the checkbox is not checked), phoenix_test seems to grab the value in the hidden input (because it's the first input in the dom?) and ignores the later checkbox regardless of whether it is checked.