### PR TITLE
Fix checked checkbox being overridden by hidden input

### DIFF
--- a/lib/phoenix_test/form.ex
+++ b/lib/phoenix_test/form.ex
@@ -61,15 +61,19 @@ defmodule PhoenixTest.Form do
 
   def has_action?(form), do: Utils.present?(form.action)
 
+  @hidden_inputs "input[type=hidden]"
+  @checked_radio_buttons "input:not([disabled])[type=radio][checked=checked][value]"
+  @checked_checkboxes "input:not([disabled])[type=checkbox][checked=checked][value]"
+  @pre_filled_text_inputs "input:not([disabled])[type=text][value]"
+  @pre_filled_default_text_inputs "input:not([disabled]):not([type])[value]"
+
   defp form_data(form) do
     %{}
-    |> put_form_data("input[type=hidden]", form)
-    |> put_form_data("input[type=radio][checked=checked][value]", form)
-    |> put_form_data("input[type=checkbox][checked=checked][value]", form)
-    |> put_form_data(
-      "input:not([disabled]):not([type=radio]):not([type=checkbox]):not([type=button]):not([type=submit])[value]",
-      form
-    )
+    |> put_form_data(@hidden_inputs, form)
+    |> put_form_data(@checked_radio_buttons, form)
+    |> put_form_data(@checked_checkboxes, form)
+    |> put_form_data(@pre_filled_text_inputs, form)
+    |> put_form_data(@pre_filled_default_text_inputs, form)
     |> put_form_data_select(form)
   end
 

--- a/test/phoenix_test/form_test.exs
+++ b/test/phoenix_test/form_test.exs
@@ -34,6 +34,8 @@ defmodule PhoenixTest.FormTest do
         <input type="hidden" name="method" value="delete"/>
         <input name="input" value="value" />
 
+        <input type="text" name="text-input" value="text value" />
+
         <select name="select">
           <option value="not_selected">Not selected</option>
           <option value="selected" selected>Selected</option>
@@ -56,6 +58,7 @@ defmodule PhoenixTest.FormTest do
       assert %{
                "method" => "delete",
                "input" => "value",
+               "text-input" => "text value",
                "select" => "selected",
                "checkbox" => "checked",
                "radio" => "checked"
@@ -66,12 +69,40 @@ defmodule PhoenixTest.FormTest do
       html = """
       <form id="form">
         <input name="input" value="value" disabled />
+        <input name="checkbox" type="checkbox" value="checked" checked disabled />
+        <input name="radio" type="radio" value="checked" checked disabled />
       </form>
       """
 
       form = Form.find!(html, "form")
 
       assert %{} == form.form_data
+    end
+
+    test "ignores hidden value for checkbox when checked" do
+      html = """
+      <form id="form">
+        <input name="checkbox" type="hidden" value="unchecked" />
+        <input name="checkbox" type="checkbox" value="checked" checked />
+      </form>
+      """
+
+      form = Form.find!(html, "form")
+
+      assert %{"checkbox" => "checked"} = form.form_data
+    end
+
+    test "uses hidden value for checkbox when unchecked" do
+      html = """
+      <form id="form">
+        <input name="checkbox" type="hidden" value="unchecked" />
+        <input name="checkbox" type="checkbox" value="checked" />
+      </form>
+      """
+
+      form = Form.find!(html, "form")
+
+      assert %{"checkbox" => "unchecked"} = form.form_data
     end
 
     test "submit_button returns the only button in the form" do


### PR DESCRIPTION
Resolves #https://github.com/germsvel/phoenix_test/pull/67

What changed?
============

From #67:

> When submitting a form with a checkbox that has an accompanying hidden
input (to populate the params when the checkbox is not checked), our current implementation grabs the value in the hidden input and ignores the later checkbox regardless of whether it is checked.

That's happening because our value is being overridden by the later inclusion of "pre-filled" inputs. The last `put_form_data` call in our `Form`'s attempt to populate the data (meant to capture inputs with `text` or with no type) has a lot of exclusion CSS (i.e. `:not()`) which did not exclude hidden inputs.

We change our queries to be more explicit by splitting the query to grab text and default text inputs into two queries which do not have to exclude so many other types.

Co-authored-by: @totaltrash