### PR TITLE
Fix `assert_path`/`refute_path` to handle live patching

### DIFF
--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -7,6 +7,7 @@ defmodule PhoenixTest.Assertions do
   alias PhoenixTest.Html
   alias PhoenixTest.Query
   alias PhoenixTest.Selectors
+  alias PhoenixTest.Utils
 
   @doc """
   Asserts that the rendered HTML content within the given session contains an
@@ -209,13 +210,13 @@ defmodule PhoenixTest.Assertions do
   end
 
   def assert_path(session, path) do
-    current_path = session.current_path
+    uri = URI.parse(session.current_path)
 
-    if current_path == path do
+    if uri.path == path do
       assert true
     else
       msg = """
-      Expected path to be #{inspect(path)} but got #{inspect(current_path)}
+      Expected path to be #{inspect(path)} but got #{inspect(uri.path)}
       """
 
       raise AssertionError, msg
@@ -233,15 +234,18 @@ defmodule PhoenixTest.Assertions do
   end
 
   defp assert_query_params(session, params) do
-    conn = session.conn
+    params = Utils.stringify_keys_and_values(params)
 
-    if conn.query_params == params do
+    uri = URI.parse(session.current_path)
+    query_params = URI.decode_query(uri.query)
+
+    if query_params == params do
       assert true
     else
       params_string = URI.encode_query(params)
 
       msg = """
-      Expected query params to be #{inspect(params_string)} but got #{inspect(conn.query_string)}
+      Expected query params to be #{inspect(params_string)} but got #{inspect(uri.query)}
       """
 
       raise AssertionError, msg
@@ -251,9 +255,9 @@ defmodule PhoenixTest.Assertions do
   end
 
   def refute_path(session, path) do
-    request_path = session.conn.request_path
+    uri = URI.parse(session.current_path)
 
-    if request_path == path do
+    if uri.path == path do
       msg = """
       Expected path not to be #{inspect(path)}
       """
@@ -273,9 +277,12 @@ defmodule PhoenixTest.Assertions do
   end
 
   defp refute_query_params(session, params) do
-    conn = session.conn
+    params = Utils.stringify_keys_and_values(params)
 
-    if conn.query_params == params do
+    uri = URI.parse(session.current_path)
+    query_params = URI.decode_query(uri.query)
+
+    if query_params == params do
       params_string = URI.encode_query(params)
 
       msg = """

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -7,7 +7,7 @@ defmodule PhoenixTest.Live do
 
   @endpoint Application.compile_env(:phoenix_test, :endpoint)
 
-  defstruct view: nil, conn: nil, active_form: ActiveForm.new(), within: :none, current_path: nil
+  defstruct view: nil, conn: nil, active_form: ActiveForm.new(), within: :none, current_path: ""
 
   def build(conn) do
     {:ok, view, _html} = live(conn)
@@ -281,6 +281,22 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   end
 
   defp maybe_redirect(html, session) when is_binary(html) do
-    session
+    maybe_put_patch_path(session)
+  end
+
+  defp maybe_put_patch_path(session) do
+    case fetch_patch_path(session.view) do
+      :no_path ->
+        session
+
+      path when is_binary(path) ->
+        %{session | current_path: path}
+    end
+  end
+
+  defp fetch_patch_path(view) do
+    assert_patch(view, 0)
+  rescue
+    ArgumentError -> :no_path
   end
 end

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -3,10 +3,11 @@ defmodule PhoenixTest.Static do
 
   alias PhoenixTest.ActiveForm
 
-  defstruct conn: nil, active_form: ActiveForm.new(), within: :none, current_path: nil
+  defstruct conn: nil, active_form: ActiveForm.new(), within: :none, current_path: ""
 
   def build(conn) do
-    %__MODULE__{conn: conn, current_path: conn.request_path}
+    current_path = conn.request_path <> "?" <> conn.query_string
+    %__MODULE__{conn: conn, current_path: current_path}
   end
 end
 

--- a/lib/phoenix_test/utils.ex
+++ b/lib/phoenix_test/utils.ex
@@ -14,4 +14,8 @@ defmodule PhoenixTest.Utils do
 
   def present?(term), do: !blank?(term)
   def blank?(term), do: term == nil || term == ""
+
+  def stringify_keys_and_values(map) do
+    Map.new(map, fn {k, v} -> {to_string(k), to_string(v)} end)
+  end
 end

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -7,7 +7,7 @@ defmodule PhoenixTest.IndexLive do
     <h1 id="title" class="title" data-role="title">LiveView main page</h1>
 
     <.link navigate="/live/page_2">Navigate link</.link>
-    <.link patch="/live/index?details=true">Patch link</.link>
+    <.link patch="/live/index?details=true&foo=bar">Patch link</.link>
     <.link href="/page/index">Navigate to non-liveview</.link>
 
     <.link class="multiple_links" href="/live/page_3">Multiple links</.link>


### PR DESCRIPTION
Resolves #62 

What changed?
=============

Unlike regular page navigations and live navigations, live patching doesn't actually exhibit different behavior after a `render_click` or `render_submit` (like a live navigate does, for example).

That makes "knowing" the current path hard when a live patch has been triggered.

An ugly attempt
---------------

Live patches in LiveView tests seem to come through messages (see the `assert_navigate` private function). It's hard to intercept those messages since we don't own the client proxy.

An alternative route (which we take here) is to use what LiveViewTest exposes to us. And that's `assert_patch/2`.

The `assert_patch/2` helper returns the path that we've been patched to. The downside is that it's an assertion... so it raises if nothing's been patched.

Thus, we have an implementation that -- though ugly (avert your eyes) -- rescues an `assert_patch/2`. In the cases where a patch has been made, we get the path back. In the cases when there was no patch to begin with, we rescue that and don't update the `session.current_path`.

Another potential issue is that since we're now dealing with messages, we need to choose how long we want to wait for the patch to come through. By default, `assert_patch` waits 100ms. But since we're potentially calling `assert_patch` every time we `render_*` (and not navigate), that could make tests a lot slower. So, we opt for waiting `0` ms -- basically saying the patch needs to have happened already. If that proves to be an issue in the future, we can try to handle it then.