### PR TITLE
Fix: Deep merge nested form button value (static)

### DIFF
--- a/lib/phoenix_test/form.ex
+++ b/lib/phoenix_test/form.ex
@@ -106,7 +106,7 @@ defmodule PhoenixTest.Form do
 
   def put_button_data(form, %Button{} = button) do
     button_data = Button.to_form_data(button)
-    update_in(form.form_data, fn data -> Map.merge(button_data, data) end)
+    update_in(form.form_data, fn data -> DeepMerge.deep_merge(button_data, data) end)
   end
 
   defp to_form_field(element) do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -161,7 +161,7 @@ defmodule PhoenixTest.LiveTest do
       |> visit("/live/index")
       |> fill_in("User Name", with: "Aragorn")
       |> click_button("Save Nested Form")
-      |> assert_has("#form-data", text: "no-phx-change-form-button: save")
+      |> assert_has("#form-data", text: "user:no-phx-change-form-button: save")
     end
 
     test "includes default data if form is untouched", %{conn: conn} do

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -233,7 +233,7 @@ defmodule PhoenixTest.StaticTest do
       |> visit("/page/index")
       |> fill_in("User Name", with: "Aragorn")
       |> click_button("Save Nested Form")
-      |> assert_has("#form-data", text: "save-button: nested-form-save")
+      |> assert_has("#form-data", text: "user:save-button: nested-form-save")
     end
 
     test "can handle clicking button that does not submit form after fill_in", %{conn: conn} do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -111,7 +111,7 @@ defmodule PhoenixTest.IndexLive do
         <option value="false">False</option>
       </select>
 
-      <button type="submit" name="no-phx-change-form-button" value="save">
+      <button type="submit" name="user[no-phx-change-form-button]" value="save">
         Save Nested Form
       </button>
     </form>

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -132,7 +132,7 @@ defmodule PhoenixTest.PageView do
         <option value="false">False</option>
       </select>
 
-      <button name="save-button" value="nested-form-save">Save Nested Form</button>
+      <button name="user[save-button]" value="nested-form-save">Save Nested Form</button>
     </form>
 
     <form id="full-form" method="post" action="/page/create_record">


### PR DESCRIPTION
**Given**
a "static" form
```html
<input name="user[name]" value="Ada" />
<button name="user[action]" value="save">Save</button>
```

**When**
I click on the "Save" button

**Then** (actual behaviour)
this is submitted
```ex
form_data = %{"user" => %{"name" => "Ada"}}
```

**Instead of** (expected behaviour)
```ex
form_data = %{"user" => %{"name" => "Ada", "action" => "save"}}
```

## Remarks
Already correctly implemented by LiveView test.