### PR TITLE
Fix: Preserve '?' in checkbox name

### DIFF
--- a/lib/phoenix_test/utils.ex
+++ b/lib/phoenix_test/utils.ex
@@ -2,7 +2,7 @@ defmodule PhoenixTest.Utils do
   @moduledoc false
 
   def name_to_map(name, value) do
-    parts = Regex.scan(~r/[\w|-]+/, name)
+    parts = Regex.scan(~r/[\w\?|-]+/, name)
 
     parts
     |> List.flatten()

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -448,6 +448,14 @@ defmodule PhoenixTest.LiveTest do
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "admin: on")
     end
+
+    test "handle checkbox name with '?'", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> check("Subscribe")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "subscribe?: on")
+    end
   end
 
   describe "uncheck/2" do

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -466,6 +466,14 @@ defmodule PhoenixTest.StaticTest do
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "admin: on")
     end
+
+    test "handle checkbox name with '?'", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> check("Subscribe")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "subscribe?: on")
+    end
   end
 
   describe "uncheck/3" do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -127,6 +127,10 @@ defmodule PhoenixTest.IndexLive do
       <label for="admin">Admin</label>
       <input id="admin" type="checkbox" name="admin" value="on" />
 
+      <input type="hidden" name="subscribe?" value="off" />
+      <label for="subscribe">Subscribe</label>
+      <input id="subscribe" type="checkbox" name="subscribe?" value="on" />
+
       <label for="race">Race</label>
       <select id="race" name="race">
         <option value="human">Human</option>

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -146,6 +146,10 @@ defmodule PhoenixTest.PageView do
       <label for="admin">Admin</label>
       <input id="admin" type="checkbox" name="admin" />
 
+      <input type="hidden" name="subscribe?" value="off" />
+      <label for="subscribe">Subscribe</label>
+      <input id="subscribe" type="checkbox" name="subscribe?" />
+
       <label for="admin_boolean">Admin (boolean)</label>
       <input id="admin_boolean" type="checkbox" name="admin_boolean" value="true" />
 


### PR DESCRIPTION
**Given**
a "static" or "live" form
```html
<input type="checkbox" name="subscribe?" value="on" />
```

**When**
I `check/2` the box and submit the form

**Then** (actual behaviour)
this is submitted
```ex
form_data = %{"subscribe" => "on"}
```

**Instead of** (expected behaviour)
```ex
form_data = %{"subscribe?" => "on"}
```