### PR TITLE
Fix uncheck/2 in nested forms

### DIFF
--- a/lib/phoenix_test/field.ex
+++ b/lib/phoenix_test/field.ex
@@ -92,7 +92,7 @@ defmodule PhoenixTest.Field do
     id = Html.attribute(field, "id")
     name = Html.attribute(field, "name")
 
-    hidden_input = Query.find!(html, "input[type='hidden'][name=#{name}]")
+    hidden_input = Query.find!(html, "input[type='hidden'][name='#{name}']")
     value = Html.attribute(hidden_input, "value")
 
     %__MODULE__{

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -456,6 +456,14 @@ defmodule PhoenixTest.LiveTest do
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "subscribe?: on")
     end
+
+    test "works in 'nested' forms", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> check("Payer")
+      |> click_button("Save Nested Form")
+      |> assert_has("#form-data", text: "user:payer: on")
+    end
   end
 
   describe "uncheck/2" do
@@ -474,6 +482,15 @@ defmodule PhoenixTest.LiveTest do
       |> uncheck("Admin")
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "admin: off")
+    end
+
+    test "works in 'nested' forms", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> check("Payer")
+      |> uncheck("Payer")
+      |> click_button("Save Nested Form")
+      |> assert_has("#form-data", text: "user:payer: off")
     end
   end
 

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -111,6 +111,10 @@ defmodule PhoenixTest.IndexLive do
         <option value="false">False</option>
       </select>
 
+      <input type="hidden" name="user[payer]" value="off" />
+      <label for="user-payer">Payer</label>
+      <input id="user-payer" type="checkbox" name="user[payer]" value="on" />
+
       <button type="submit" name="user[no-phx-change-form-button]" value="save">
         Save Nested Form
       </button>


### PR DESCRIPTION
Unchecking checkboxes in nested forms currently crashes with 

```
** (FunctionClauseError) no function clause matching in Floki.Selector.Parser.do_parse/2

     The following arguments were given to Floki.Selector.Parser.do_parse/2:

         # 1
         [{~c"]", 1}]

         # 2
         %Floki.Selector{id: nil, type: "input", classes: [], attributes: [%Floki.Selector.AttributeSelector{match_type: :equal, attribute: "name", value: "payer", flag: nil}, %Floki.Selector.AttributeSelector{match_type: :equal, attribute: "type", value: "hidden", flag: nil}], namespace: nil, pseudo_classes: [], combinator: nil}

     Attempted function clauses (showing 10 out of 21):

         defp do_parse([], selector)
         defp do_parse([{:close_parentesis, _} | t], selector)
         defp do_parse([{:comma, _} | t], selector)
         defp do_parse([{:identifier, _, namespace}, {:namespace_pipe, _} | t], selector)
         defp do_parse([{:identifier, _, type} | t], selector)
         defp do_parse([{~c"*", _} | t], selector)
         defp do_parse([{:hash, _, id} | t], selector)
         defp do_parse([{:class, _, class} | t], selector)
         defp do_parse([{~c"[", _} | t], selector)
         defp do_parse([{:pseudo_not, _} | t], selector)
         ...
         (11 clauses not shown)
```

This PR escapes brackets in the hidden input name by wrapping it in single quotes.
