### PR TITLE
Fix: support links with only query parameters

### DIFF
--- a/lib/phoenix_test/link.ex
+++ b/lib/phoenix_test/link.ex
@@ -28,4 +28,14 @@ defmodule PhoenixTest.Link do
     |> Html.attribute("data-method")
     |> Utils.present?()
   end
+
+  def maybe_append_path(link, path) do
+    link.href
+    |> URI.parse()
+    |> Map.replace_lazy(:path, fn
+      nil -> path
+      current_path -> current_path
+    end)
+    |> URI.to_string()
+  end
 end

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -68,7 +68,9 @@ defmodule PhoenixTest.Static do
       |> dispatch(@endpoint, form.method, form.action, form.data)
       |> maybe_redirect(session)
     else
-      PhoenixTest.visit(session.conn, link.href)
+      path = Link.maybe_append_path(link, session.conn.request_path)
+
+      PhoenixTest.visit(session.conn, path)
     end
   end
 

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -77,6 +77,13 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("h1", text: "LiveView main page")
     end
 
+    test "handles links with query parameters and no path", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> click_link("English")
+      |> assert_has("h1", text: "Main page")
+    end
+
     test "handles form submission via `data-method` & `data-to` attributes", %{conn: conn} do
       conn
       |> visit("/page/index")

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -41,6 +41,8 @@ defmodule PhoenixTest.PageView do
 
     <a href="/live/index">To LiveView!</a>
 
+    <a href="?lang=en">English</a>
+
     <ul id="multiple-items">
       <li>Aragorn</li>
       <li>Legolas</li>


### PR DESCRIPTION
This commit resolves an issue where links containing only query parameters without a specified path would incorrectly direct to the root path instead of the current path, unlike standard browser behavior.

Example of a link without a path:

    <a href="?lang=en">English</a>

Previously, `click_link/2` would direct to root path. In this commit the link correctly retains the current page while applying the query parameters.