### PR TITLE
Deep merge form data in nested/prefixed forms

### DIFF
--- a/lib/phoenix_test/form.ex
+++ b/lib/phoenix_test/form.ex
@@ -97,7 +97,7 @@ defmodule PhoenixTest.Form do
           {_, false, [only_selected]} -> DeepMerge.deep_merge(acc, to_form_field(select, only_selected))
           {_, true, [_ | _] = all_selected} -> DeepMerge.deep_merge(acc, to_form_field(select, all_selected))
           {[first | _], false, _} -> DeepMerge.deep_merge(acc, to_form_field(select, first))
-          {_, true, _} -> DeepMerge.merge(acc, to_form_field(select, []))
+          {_, true, _} -> DeepMerge.deep_merge(acc, to_form_field(select, []))
         end
       end)
 

--- a/lib/phoenix_test/form.ex
+++ b/lib/phoenix_test/form.ex
@@ -78,9 +78,9 @@ defmodule PhoenixTest.Form do
       form
       |> Html.all(selector)
       |> Enum.map(&to_form_field/1)
-      |> Enum.reduce(%{}, fn value, acc -> Map.merge(acc, value) end)
+      |> Enum.reduce(%{}, fn value, acc -> DeepMerge.deep_merge(acc, value) end)
 
-    Map.merge(form_data, input_fields)
+    DeepMerge.deep_merge(form_data, input_fields)
   end
 
   defp put_form_data_select(form_data, form) do
@@ -92,14 +92,14 @@ defmodule PhoenixTest.Form do
 
         case {Html.all(select, "option"), multiple, Html.all(select, "option[selected]")} do
           {[], _, _} -> acc
-          {_, false, [only_selected]} -> Map.merge(acc, to_form_field(select, only_selected))
-          {_, true, [_ | _] = all_selected} -> Map.merge(acc, to_form_field(select, all_selected))
-          {[first | _], false, _} -> Map.merge(acc, to_form_field(select, first))
-          {[first | _], true, _} -> Map.merge(acc, to_form_field(select, [first]))
+          {_, false, [only_selected]} -> DeepMerge.deep_merge(acc, to_form_field(select, only_selected))
+          {_, true, [_ | _] = all_selected} -> DeepMerge.deep_merge(acc, to_form_field(select, all_selected))
+          {[first | _], false, _} -> DeepMerge.deep_merge(acc, to_form_field(select, first))
+          {[first | _], true, _} -> DeepMerge.deep_merge(acc, to_form_field(select, [first]))
         end
       end)
 
-    Map.merge(form_data, selects)
+    DeepMerge.deep_merge(form_data, selects)
   end
 
   def put_button_data(form, nil), do: form

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -331,6 +331,8 @@ defmodule PhoenixTest.LiveTest do
       |> fill_in("User Name", with: "Aragorn")
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:name: Aragorn")
+      |> assert_has("#form-data", text: "user:payer: off")
+      |> assert_has("#form-data", text: "user:role: El Jefe")
     end
 
     test "triggers phx-change validations", %{conn: conn} do

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -382,6 +382,9 @@ defmodule PhoenixTest.StaticTest do
       |> fill_in("User Name", with: "Aragorn")
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:name: Aragorn")
+      |> assert_has("#form-data", text: "user:admin: true")
+      |> assert_has("#form-data", text: "user:payer: off")
+      |> assert_has("#form-data", text: "user:role: El Jefe")
     end
 
     test "can be combined with other forms' fill_ins (without pollution)", %{conn: conn} do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -105,6 +105,9 @@ defmodule PhoenixTest.IndexLive do
       <label for="user-name">User Name</label>
       <input id="user-name" name="user[name]" />
 
+      <label for="user-role">User Role</label>
+      <input id="user-role" name="user[role]" value="El Jefe" />
+
       <label for="user-admin">User Admin</label>
       <select id="user-admin" name="user[admin]">
         <option value="true">True</option>

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -126,11 +126,18 @@ defmodule PhoenixTest.PageView do
       <label for="user_name">User Name</label>
       <input type="text" id="user_name" name="user[name]" />
 
+      <label for="user-role">User Role</label>
+      <input id="user-role" name="user[role]" value="El Jefe" />
+
       <label for="user_admin">User Admin</label>
       <select id="user_admin" name="user[admin]">
         <option value="true">True</option>
         <option value="false">False</option>
       </select>
+
+      <input type="hidden" name="user[payer]" value="off" />
+      <label for="user-payer">Payer</label>
+      <input id="user-payer" type="checkbox" name="user[payer]" value="on" />
 
       <button name="user[save-button]" value="nested-form-save">Save Nested Form</button>
     </form>


### PR DESCRIPTION
Current implementation performs multiple passes over form defaults before merging in "user"-supplied form data.
`Map.merge` works well for flat forms where `name` attributes on inputs are not nested. When nesting is in place and
attributes look like this: `user[name]`, this approach breaks as default check boxes override hidden inputs, select
defaults override everything else, etc. 

This patch uses replaces `Map.merge` with `DeepMerge.deep_merge` for form data helpers, in the same way it's already
done in some places in the live driver.

N.B. this bug occurs for the static driver but not for the live driver that already uses `DeepMerge`.
