### PR TITLE
Do not assume first option to be selected by default for multiple select

### DIFF
--- a/lib/phoenix_test/form.ex
+++ b/lib/phoenix_test/form.ex
@@ -95,7 +95,7 @@ defmodule PhoenixTest.Form do
           {_, false, [only_selected]} -> Map.merge(acc, to_form_field(select, only_selected))
           {_, true, [_ | _] = all_selected} -> Map.merge(acc, to_form_field(select, all_selected))
           {[first | _], false, _} -> Map.merge(acc, to_form_field(select, first))
-          {[first | _], true, _} -> Map.merge(acc, to_form_field(select, [first]))
+          {_, true, _} -> Map.merge(acc, to_form_field(select, []))
         end
       end)
 

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -424,6 +424,13 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("#form-data", text: "race: elf")
     end
 
+    test "picks first by default", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "race: human")
+    end
+
     test "works in 'nested' forms", %{conn: conn} do
       conn
       |> visit("/page/index")
@@ -438,6 +445,13 @@ defmodule PhoenixTest.StaticTest do
       |> select(["Elf", "Dwarf"], from: "Race 2")
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "race_2: [elf,dwarf]")
+    end
+
+    test "honors empty default for multi select", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "race_2: []")
     end
   end
 


### PR DESCRIPTION
Current behavior for a multiple select is copying the default behavior for single select: assume the first option to be
selected by default. This is fine for single selects (that's how a "combo box" works after all, an "empty" options needs
to be included explicitly at the top), but this is not how multiple select works, as nothing is selected by default and
it's not safe to assume the first option to be desired.

This patch doesn't assume the first option in a multiple select to be selected by default.
