### PR TITLE
Support default values on textareas

### DIFF
--- a/lib/phoenix_test/form.ex
+++ b/lib/phoenix_test/form.ex
@@ -81,6 +81,7 @@ defmodule PhoenixTest.Form do
       form_data(@pre_filled_text_inputs, form) ++
       form_data(@pre_filled_number_inputs, form) ++
       form_data(@pre_filled_default_text_inputs, form) ++
+      form_data_textarea(form) ++
       form_data_select(form)
   end
 
@@ -88,6 +89,14 @@ defmodule PhoenixTest.Form do
     form
     |> Html.all(selector)
     |> Enum.flat_map(&to_form_field/1)
+  end
+
+  defp form_data_textarea(form) do
+    form
+    |> Html.all("textarea:not([disabled])")
+    |> Enum.flat_map(fn {"textarea", _attrs, value_elements} = textarea ->
+      to_form_field(textarea, value_elements)
+    end)
   end
 
   defp form_data_select(form) do
@@ -119,13 +128,16 @@ defmodule PhoenixTest.Form do
 
   defp to_form_field(name_element, value_elements) when is_list(value_elements) do
     name = Html.attribute(name_element, "name")
-    Enum.map(value_elements, &{name, Html.attribute(&1, "value")})
+    Enum.map(value_elements, &{name, element_value(&1)})
   end
 
   defp to_form_field(name_element, value_element) do
     name = Html.attribute(name_element, "name")
-    value = Html.attribute(value_element, "value")
-    [{name, value}]
+    [{name, element_value(value_element)}]
+  end
+
+  defp element_value(element) do
+    Html.attribute(element, "value") || Html.text(element)
   end
 
   defp operative_method({"form", _attrs, fields} = form) do

--- a/test/phoenix_test/form_test.exs
+++ b/test/phoenix_test/form_test.exs
@@ -125,6 +125,10 @@ defmodule PhoenixTest.FormTest do
 
         <input name="radio" type="radio" value="not_checked" />
         <input name="radio" type="radio" value="checked" checked />
+
+        <textarea name="textarea">
+          Default text
+        </textarea>
       </form>
       """
 
@@ -137,7 +141,8 @@ defmodule PhoenixTest.FormTest do
                "select" => "selected",
                "select_multiple" => ["select_1", "select_2"],
                "checkbox" => "checked",
-               "radio" => "checked"
+               "radio" => "checked",
+               "textarea" => "Default text"
              } = Form.build_data(form.form_data)
     end
 
@@ -147,6 +152,7 @@ defmodule PhoenixTest.FormTest do
         <input name="input" value="value" disabled />
         <input name="checkbox" type="checkbox" value="checked" checked disabled />
         <input name="radio" type="radio" value="checked" checked disabled />
+        <textarea name="textarea" disabled>Disabled value</textarea>
       </form>
       """
 

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -172,6 +172,8 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "contact: mail")
       |> assert_has("#form-data", text: "level: 7")
       |> assert_has("#form-data", text: "full_form_button: save")
+      |> assert_has("#form-data", text: "notes: Prefilled notes")
+      |> refute_has("#form-data", text: "disabled_textarea:")
     end
 
     test "can click button that does not submit form after filling form", %{conn: conn} do

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -252,6 +252,8 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("#form-data", text: "contact: mail")
       |> assert_has("#form-data", text: "level: 7")
       |> assert_has("#form-data", text: "full_form_button: save")
+      |> assert_has("#form-data", text: "notes: Prefilled notes")
+      |> refute_has("#form-data", text: "disabled_textarea:")
     end
 
     test "raises error if trying to submit via `data-` attributes but incomplete", %{conn: conn} do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -171,6 +171,12 @@ defmodule PhoenixTest.IndexLive do
 
       <label for="notes">Notes</label>
       <textarea id="notes" name="notes" rows="5" cols="33">
+      Prefilled notes
+      </textarea>
+
+      <label for="disabled_textarea">Disabled textaread</label>
+      <textarea id="disabled_textarea" name="disabled_textarea" rows="5" cols="33" disabled>
+      Prefilled content 
       </textarea>
 
       <button type="submit" name="full_form_button" value="save">Save Full Form</button>

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -193,6 +193,12 @@ defmodule PhoenixTest.PageView do
 
       <label for="notes">Notes</label>
       <textarea id="notes" name="notes" rows="5" cols="33">
+      Prefilled notes
+      </textarea>
+
+      <label for="disabled_textarea">Disabled textaread</label>
+      <textarea id="disabled_textarea" name="disabled_textarea" rows="5" cols="33" disabled>
+      Prefilled content 
       </textarea>
 
       <div>


### PR DESCRIPTION
This PR adds support for default / pre-filled values in `<textarea>` form elements. The default `put_form_data` helper function can't work here, as `<input>` elements have the value in an attribute but `<textarea>` holds it as a text child.
