### PR TITLE
Refactor: Move assertions into 'Driver' protocol

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -196,7 +196,6 @@ defmodule PhoenixTest do
 
   import Phoenix.ConnTest
 
-  alias PhoenixTest.Assertions
   alias PhoenixTest.Driver
 
   @endpoint Application.compile_env(:phoenix_test, :endpoint)
@@ -691,7 +690,7 @@ defmodule PhoenixTest do
   assert_has(session, "#user")
   ```
   """
-  defdelegate assert_has(session, selector), to: Assertions
+  defdelegate assert_has(session, selector), to: Driver
 
   @doc """
   Assert helper to ensure an element with given CSS selector and options.
@@ -734,7 +733,7 @@ defmodule PhoenixTest do
   assert_has(session, ".posts", at: 2, text: "Hello")
   ```
   """
-  defdelegate assert_has(session, selector, opts), to: Assertions
+  defdelegate assert_has(session, selector, opts), to: Driver
 
   @doc """
   Opposite of `assert_has/2` helper. Verifies that element with
@@ -754,7 +753,7 @@ defmodule PhoenixTest do
   refute_has(session, "#user")
   ```
   """
-  defdelegate refute_has(session, selector), to: Assertions
+  defdelegate refute_has(session, selector), to: Driver
 
   @doc """
   Opposite of `assert_has/3` helper. Verifies that element with
@@ -795,7 +794,7 @@ defmodule PhoenixTest do
   refute_has(session, ".posts", at: 2, text: "Hello")
   ```
   """
-  defdelegate refute_has(session, selector, opts), to: Assertions
+  defdelegate refute_has(session, selector, opts), to: Driver
 
   @doc """
   Assert helper to verify current request path. Takes an optional `query_params`
@@ -822,12 +821,12 @@ defmodule PhoenixTest do
   |> assert_path("/users", query_params: %{name: "frodo"})
   ```
   """
-  defdelegate assert_path(session, path), to: Assertions
+  defdelegate assert_path(session, path), to: Driver
 
   @doc """
   Same as `assert_path/2` but takes an optional `query_params` map.
   """
-  defdelegate assert_path(session, path, opts), to: Assertions
+  defdelegate assert_path(session, path, opts), to: Driver
 
   @doc """
   Verifies current request path is NOT the one provided. Takes an optional
@@ -854,11 +853,11 @@ defmodule PhoenixTest do
   |> refute_path("/users", query_params: %{name: "frodo"})
   ```
   """
-  defdelegate refute_path(session, path), to: Assertions
+  defdelegate refute_path(session, path), to: Driver
 
   @doc """
   Same as `refute_path/2` but takes an optional `query_params` for more specific
   refutation.
   """
-  defdelegate refute_path(session, path, opts), to: Assertions
+  defdelegate refute_path(session, path, opts), to: Driver
 end

--- a/lib/phoenix_test/driver.ex
+++ b/lib/phoenix_test/driver.ex
@@ -16,4 +16,13 @@ defprotocol PhoenixTest.Driver do
   def unwrap(session, fun)
   def open_browser(session)
   def open_browser(session, open_fun)
+
+  def assert_has(session, selector)
+  def assert_has(session, selector, opts)
+  def refute_has(session, selector)
+  def refute_has(session, selector, opts)
+  def assert_path(session, path)
+  def assert_path(session, path, opts)
+  def refute_path(session, path)
+  def refute_path(session, path, opts)
 end

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -300,6 +300,7 @@ defmodule PhoenixTest.Live do
 end
 
 defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
+  alias PhoenixTest.Assertions
   alias PhoenixTest.Live
 
   defdelegate render_page_title(session), to: Live
@@ -318,4 +319,13 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   defdelegate open_browser(session), to: Live
   defdelegate open_browser(session, open_fun), to: Live
   defdelegate unwrap(session, fun), to: Live
+
+  defdelegate assert_has(session, selector), to: Assertions
+  defdelegate assert_has(session, selector, opts), to: Assertions
+  defdelegate refute_has(session, selector), to: Assertions
+  defdelegate refute_has(session, selector, opts), to: Assertions
+  defdelegate assert_path(session, path), to: Assertions
+  defdelegate assert_path(session, path, opts), to: Assertions
+  defdelegate refute_path(session, path), to: Assertions
+  defdelegate refute_path(session, path, opts), to: Assertions
 end

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -269,6 +269,7 @@ defmodule PhoenixTest.Static do
 end
 
 defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
+  alias PhoenixTest.Assertions
   alias PhoenixTest.Static
 
   defdelegate render_page_title(session), to: Static
@@ -287,4 +288,13 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
   defdelegate open_browser(session), to: Static
   defdelegate open_browser(session, open_fun), to: Static
   defdelegate unwrap(session, fun), to: Static
+
+  defdelegate assert_has(session, selector), to: Assertions
+  defdelegate assert_has(session, selector, opts), to: Assertions
+  defdelegate refute_has(session, selector), to: Assertions
+  defdelegate refute_has(session, selector, opts), to: Assertions
+  defdelegate assert_path(session, path), to: Assertions
+  defdelegate assert_path(session, path, opts), to: Assertions
+  defdelegate refute_path(session, path), to: Assertions
+  defdelegate refute_path(session, path, opts), to: Assertions
 end

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -6,6 +6,7 @@ defmodule PhoenixTest.AssertionsTest do
   import PhoenixTest.TestHelpers
 
   alias ExUnit.AssertionError
+  alias PhoenixTest.Live
 
   setup do
     %{conn: Phoenix.ConnTest.build_conn()}
@@ -568,19 +569,19 @@ defmodule PhoenixTest.AssertionsTest do
 
   describe "assert_path" do
     test "asserts the session's current path" do
-      session = %{current_path: "/page/index"}
+      session = %Live{current_path: "/page/index"}
 
       assert_path(session, "/page/index")
     end
 
     test "asserts query params are the same" do
-      session = %{current_path: "/page/index?hello=world"}
+      session = %Live{current_path: "/page/index?hello=world"}
 
       assert_path(session, "/page/index", query_params: %{"hello" => "world"})
     end
 
     test "order of query params does not matter" do
-      session = %{current_path: "/page/index?hello=world&foo=bar"}
+      session = %Live{current_path: "/page/index?hello=world&foo=bar"}
 
       assert_path(session, "/page/index", query_params: %{"foo" => "bar", "hello" => "world"})
     end
@@ -592,7 +593,7 @@ defmodule PhoenixTest.AssertionsTest do
         """)
 
       assert_raise AssertionError, msg, fn ->
-        session = %{current_path: "/page/index"}
+        session = %Live{current_path: "/page/index"}
 
         assert_path(session, "/page/not-index")
       end
@@ -605,7 +606,7 @@ defmodule PhoenixTest.AssertionsTest do
         """)
 
       assert_raise AssertionError, msg, fn ->
-        session = %{current_path: "/page/index"}
+        session = %Live{current_path: "/page/index"}
 
         assert_path(session, "/page/index", query_params: %{foo: "bar", details: true})
       end
@@ -618,7 +619,7 @@ defmodule PhoenixTest.AssertionsTest do
         """)
 
       assert_raise AssertionError, msg, fn ->
-        session = %{current_path: "/page/index?hello=world&hi=bye"}
+        session = %Live{current_path: "/page/index?hello=world&hi=bye"}
 
         assert_path(session, "/page/index", query_params: %{"goodbye" => "world", "hi" => "bye"})
       end
@@ -627,13 +628,13 @@ defmodule PhoenixTest.AssertionsTest do
 
   describe "refute_path" do
     test "refute the given path is the current path" do
-      session = %{current_path: "/page/index"}
+      session = %Live{current_path: "/page/index"}
 
       refute_path(session, "/page/page_2")
     end
 
     test "refutes query params are the same" do
-      session = %{current_path: "/page/index?hello=world"}
+      session = %Live{current_path: "/page/index?hello=world"}
 
       refute_path(session, "/page/index", query_params: %{"hello" => "not-world"})
     end
@@ -645,7 +646,7 @@ defmodule PhoenixTest.AssertionsTest do
         """)
 
       assert_raise AssertionError, msg, fn ->
-        session = %{current_path: "/page/index"}
+        session = %Live{current_path: "/page/index"}
 
         refute_path(session, "/page/index")
       end
@@ -658,7 +659,7 @@ defmodule PhoenixTest.AssertionsTest do
         """)
 
       assert_raise AssertionError, msg, fn ->
-        session = %{current_path: "/page/index?hello=world&hi=bye"}
+        session = %Live{current_path: "/page/index?hello=world&hi=bye"}
 
         refute_path(session, "/page/index", query_params: %{"hello" => "world", "hi" => "bye"})
       end


### PR DESCRIPTION
Extracted from #74 

## Goal
Allow more flexibility for Driver implementations.

## Background
Browser-based testing is inherently decoupled, and usually involves some retry/await concept to ensure the rendered web UI is up to date with the server side state.

Wrapping the assertion functions in the `Driver` protocol allows flexibility for browser-based Drivers:
- use built-in framework assertions (Wallaby, Playwright) that have an integrated retry
- build custom retry wrapper around `PhoenixTest.Assertions`
