### PR TITLE
Improve test: Add '[]' suffix to multi-select name attr

### DIFF
--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -172,7 +172,7 @@ defmodule PhoenixTest.PageView do
       </select>
 
       <label for="race_2">Race 2</label>
-      <select multiple id="race_2" name="race_2">
+      <select multiple id="race_2" name="race_2[]">
         <option value="human">Human</option>
         <option value="elf">Elf</option>
         <option value="dwarf">Dwarf</option>


### PR DESCRIPTION
Extracted from #74

Align `PageView` with `IndexLive`:
`<select multiple>` should use name `attr` ending in `[]`.

Even though the tests do not currently fail (decode multiple values), an actual Phoenix app would fail (decode only a single value).

As a follow-up, it might be good to make the `Static` driver stricter to emulate real-world behaviour.

https://github.com/elixir-plug/plug/blob/v1.16.0/lib/plug/parsers/urlencoded.ex
https://github.com/elixir-plug/plug/blob/v1.16.0/lib/plug/conn/query.ex#L24

```ex
  Lists are created with `[]`:

      iex> decode("foo[]=bar&foo[]=baz")["foo"]
      ["bar", "baz"]
```