### PR TITLE
Query associated element with `[id='<id>']`

### DIFF
--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -475,7 +475,7 @@ defmodule PhoenixTest.Query do
   end
 
   defp find_element_with_id(html, id, label) do
-    case find(html, "##{id}") do
+    case find(html, "[id='#{id}']") do
       :not_found -> {:not_found, :missing_id, label}
       {:found, _el} = found -> found
     end

--- a/test/phoenix_test/form_test.exs
+++ b/test/phoenix_test/form_test.exs
@@ -6,7 +6,7 @@ defmodule PhoenixTest.FormTest do
   alias PhoenixTest.Form
 
   describe "find!" do
-    test " finds a form by selector" do
+    test "finds a form by selector" do
       html = """
       <form id="user-form">
       </form>

--- a/test/phoenix_test/query_test.exs
+++ b/test/phoenix_test/query_test.exs
@@ -510,6 +510,17 @@ defmodule PhoenixTest.QueryTest do
       assert {"input", [{"id", "greeting"}], []} = element
     end
 
+    test "returns found element label points to (even if id has ? character)" do
+      html = """
+      <label for="greeting?">Hello</label>
+      <input id="greeting?"/>
+      """
+
+      {:found, element} = Query.find_by_label(html, "Hello")
+
+      assert {"input", [{"id", "greeting?"}], []} = element
+    end
+
     test "returns found element when association is implicit" do
       html = """
       <label>


### PR DESCRIPTION
Resolves #97

What changed?
=============

It turns out that Chrome and Firefox don't accept `#text?` as a valid selector. But having a `?` in an element's `id` seems to be valid HTML.

Thank to https://github.com/philss/floki/issues/583 for the info.

To support that, we update our `Query.find_by_label` function to query by `[id='<id>']` instead of using `#<id>`.