### PR TITLE
Issues with unchecking checkboxes and unselecting items from multiple select

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -444,10 +444,24 @@ defmodule PhoenixTest.LiveTest do
     test "works for multiple select", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("Elf", from: "Race")
       |> select(["Elf", "Dwarf"], from: "Race 2")
       |> click_button("Save Full Form")
-      |> assert_has("#form-data", text: "[elf, dwarf]")
+      |> assert_has("#form-data", text: "race_2: [elf, dwarf]")
+    end
+
+    test "prefilled multiple select", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "race_2: [elf]")
+    end
+
+    test "deselect all from multiple select", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> select([], from: "Race 2")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "race_2: []")
     end
   end
 
@@ -493,6 +507,14 @@ defmodule PhoenixTest.LiveTest do
       |> uncheck("Admin")
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "admin: off")
+    end
+
+    test "sends no value if no hidden input", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> uncheck("Reader")
+      |> click_button("Save Full Form")
+      |> refute_has("#form-data", text: "roles:")
     end
 
     test "can uncheck a previous check/2 in the test", %{conn: conn} do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -152,10 +152,17 @@ defmodule PhoenixTest.IndexLive do
       <label for="race_2">Race 2</label>
       <select multiple id="race_2" name="race_2[]">
         <option value="human">Human</option>
-        <option value="elf">Elf</option>
+        <option value="elf" selected>Elf</option>
         <option value="dwarf">Dwarf</option>
         <option value="orc">Orc</option>
       </select>
+
+      <div>
+        <input type="checkbox" name="roles[]" id="role_reader" value="reader" checked />
+        <label for="role_reader">Reader</label>
+        <input type="checkbox" name="roles[]" id="role_writer" value="writer" />
+        <label for="role_writer">Writer</label>
+      </div>
 
       <fieldset>
         <legend>Please select your preferred contact method:</legend>


### PR DESCRIPTION
This commit has some failing tests for a number of issues, but they all relate to removing items from multiple selects or checkbox groups.

1. Can't unselect options from a multiple select (maybe we need an `unselect()` helper)
2. Can't uncheck checkboxes that aren't backed by a hidden input
3. A form prefilled with one selected item in a multiple select has duplicate items (same for checkbox group)

I've had a quick go at an implementation to fix these issues, but I can't quite get my head around what you would need to do to remove items from a form in a session. I'll give it another crack soon, but any pointers would be awesome