### PR TITLE
Handle checkbox phx-click outside of form

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -627,6 +627,7 @@ defmodule PhoenixTest do
     |> Field.find_input!(label)
     |> then(&Driver.fill_in_field_data(session, &1))
   end
+
   @doc """
   Helper to submit a pre-filled form without clicking a button (see `fill_in/3`,
   `select/3`, `choose/2`, etc. for how to fill a form.)

--- a/lib/phoenix_test/field.ex
+++ b/lib/phoenix_test/field.ex
@@ -5,9 +5,10 @@ defmodule PhoenixTest.Field do
   alias PhoenixTest.Form
   alias PhoenixTest.Html
   alias PhoenixTest.Query
+  alias PhoenixTest.Utils
 
-  @enforce_keys ~w[source_raw label id name value selector]a
-  defstruct ~w[source_raw label id name value selector]a
+  @enforce_keys ~w[source_raw parsed label id name value selector]a
+  defstruct ~w[source_raw parsed label id name value selector]a
 
   def find_input!(html, label) do
     field = Query.find_by_label!(html, label)
@@ -17,6 +18,7 @@ defmodule PhoenixTest.Field do
 
     %__MODULE__{
       source_raw: html,
+      parsed: field,
       label: label,
       id: id,
       name: name,
@@ -62,6 +64,7 @@ defmodule PhoenixTest.Field do
 
     %__MODULE__{
       source_raw: html,
+      parsed: field,
       label: label,
       id: id,
       name: name,
@@ -78,6 +81,7 @@ defmodule PhoenixTest.Field do
 
     %__MODULE__{
       source_raw: html,
+      parsed: field,
       label: label,
       id: id,
       name: name,
@@ -96,6 +100,7 @@ defmodule PhoenixTest.Field do
 
     %__MODULE__{
       source_raw: html,
+      parsed: field,
       label: label,
       id: id,
       name: name,
@@ -112,7 +117,17 @@ defmodule PhoenixTest.Field do
     [{field.name, field.value}]
   end
 
+  def parent_form(field) do
+    Form.find_by_descendant(field.source_raw, field)
+  end
+
   def parent_form!(field) do
     Form.find_by_descendant!(field.source_raw, field)
+  end
+
+  def phx_click?(field) do
+    field.parsed
+    |> Html.attribute("phx-click")
+    |> Utils.present?()
   end
 end

--- a/lib/phoenix_test/form.ex
+++ b/lib/phoenix_test/form.ex
@@ -15,6 +15,13 @@ defmodule PhoenixTest.Form do
     |> build()
   end
 
+  def find_by_descendant(html, descendant) do
+    case Query.find_ancestor(html, "form", descendant_selector(descendant)) do
+      {:found, element} -> {:ok, build(element)}
+      other -> {:error, other}
+    end
+  end
+
   def find_by_descendant!(html, descendant) do
     html
     |> Query.find_ancestor!("form", descendant_selector(descendant))

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -508,6 +508,13 @@ defmodule PhoenixTest.LiveTest do
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:payer: off")
     end
+
+    test "works outside a form", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> check("Redirect checkbox")
+      |> assert_path("/live/page_2")
+    end
   end
 
   describe "choose/2" do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -247,6 +247,13 @@ defmodule PhoenixTest.IndexLive do
       <input id="email-on-change" name="email" />
     </form>
 
+    <label for="redirect-checkbox">Redirect checkbox</label>
+    <input
+      id="redirect-checkbox"
+      type="checkbox"
+      phx-click={Phoenix.LiveView.JS.patch("/live/page_2")}
+    />
+
     <div id="hook" phx-hook="SomeHook"></div>
     <div id="hook-with-redirect" phx-hook="SomeOtherHook"></div>
     """


### PR DESCRIPTION
Fix #101

## Out of scope
While this fixes this specific case, a more thorough investigation and solution might be better:
- `phx-change` on `<input type="text"` without a form
- `phx-click` on a checkbox inside a form (should trigger both events: `phx-click` on checkbox AND `phx-change` on form)