### PR TITLE
Fix multi checkbox: Add hidden input only once

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -627,6 +627,7 @@ defmodule PhoenixTest do
     |> Field.find_input!(label)
     |> then(&Driver.fill_in_field_data(session, &1))
   end
+
   @doc """
   Helper to submit a pre-filled form without clicking a button (see `fill_in/3`,
   `select/3`, `choose/2`, etc. for how to fill a form.)

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -480,6 +480,15 @@ defmodule PhoenixTest.LiveTest do
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:payer: on")
     end
+
+    test "handles checkbox group incl. hidden input", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> check("Human")
+      |> check("Elf")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "race_3: [dwarf,human,elf]")
+    end
   end
 
   describe "uncheck/2" do

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -502,6 +502,15 @@ defmodule PhoenixTest.StaticTest do
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "subscribe?: on")
     end
+
+    test "handles checkbox group incl. hidden input", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> check("Human")
+      |> check("Elf")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "race_3: [dwarf,human,elf]")
+    end
   end
 
   describe "uncheck/3" do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -157,6 +157,10 @@ defmodule PhoenixTest.IndexLive do
         <option value="orc">Orc</option>
       </select>
 
+      <input type="hidden" name="race_3[]" value="dwarf" />
+      <label><input type="checkbox" name="race_3[]" value="human" />Human</label>
+      <label><input type="checkbox" name="race_3[]" value="elf" />Elf</label>
+
       <fieldset>
         <legend>Please select your preferred contact method:</legend>
         <div>

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -186,6 +186,10 @@ defmodule PhoenixTest.PageView do
         <option value="orc">Orc</option>
       </select>
 
+      <input type="hidden" name="race_3[]" value="dwarf" />
+      <label><input type="checkbox" name="race_3[]" value="human" />Human</label>
+      <label><input type="checkbox" name="race_3[]" value="elf" />Elf</label>
+
       <fieldset>
         <legend>Please select your preferred contact method:</legend>
         <div>


### PR DESCRIPTION
## Given
```html
<input type="hidden" name="race_3[]" value="dwarf" />
<label><input type="checkbox" name="race_3[]" value="human" />Human</label>
<label><input type="checkbox" name="race_3[]" value="elf" />Elf</label>
```

```ex
|> check("Human")
|> check("Elf")
```

## Expected
```ex
race_3: [dwarf, human, elf]
```

## Actual
```ex
race_3: [dwarf, dwarf, dwarf, human, elf]
```

## Todo
- [x] Add failing test
- [ ] Fix