### PR TITLE
Handle radio buttons with phx-click

### DIFF
--- a/lib/phoenix_test/field.ex
+++ b/lib/phoenix_test/field.ex
@@ -5,9 +5,10 @@ defmodule PhoenixTest.Field do
   alias PhoenixTest.Form
   alias PhoenixTest.Html
   alias PhoenixTest.Query
+  alias PhoenixTest.Utils
 
-  @enforce_keys ~w[source_raw label id name value selector]a
-  defstruct ~w[source_raw label id name value selector]a
+  @enforce_keys ~w[source_raw parsed label id name value selector]a
+  defstruct ~w[source_raw parsed label id name value selector]a
 
   def find_input!(html, label) do
     field = Query.find_by_label!(html, label)
@@ -17,6 +18,7 @@ defmodule PhoenixTest.Field do
 
     %__MODULE__{
       source_raw: html,
+      parsed: field,
       label: label,
       id: id,
       name: name,
@@ -62,6 +64,7 @@ defmodule PhoenixTest.Field do
 
     %__MODULE__{
       source_raw: html,
+      parsed: field,
       label: label,
       id: id,
       name: name,
@@ -78,6 +81,7 @@ defmodule PhoenixTest.Field do
 
     %__MODULE__{
       source_raw: html,
+      parsed: field,
       label: label,
       id: id,
       name: name,
@@ -96,6 +100,7 @@ defmodule PhoenixTest.Field do
 
     %__MODULE__{
       source_raw: html,
+      parsed: field,
       label: label,
       id: id,
       name: name,
@@ -114,5 +119,18 @@ defmodule PhoenixTest.Field do
 
   def parent_form!(field) do
     Form.find_by_descendant!(field.source_raw, field)
+  end
+
+  def phx_click?(field) do
+    field.parsed
+    |> Html.attribute("phx-click")
+    |> Utils.present?()
+  end
+
+  def belongs_to_form?(field) do
+    case Query.find_ancestor(field.source_raw, "form", field.selector) do
+      {:found, _} -> true
+      _ -> false
+    end
   end
 end

--- a/test/phoenix_test/field_test.exs
+++ b/test/phoenix_test/field_test.exs
@@ -118,4 +118,54 @@ defmodule PhoenixTest.FieldTest do
       end
     end
   end
+
+  describe "phx_click?" do
+    test "returns true if field has a phx-click handler" do
+      html = """
+      <label for="name">Name</label>
+      <input phx-click="save" id="name" type="radio" name="name" value="Hello world"/>
+      """
+
+      field = Field.find_input!(html, "Name")
+
+      assert Field.phx_click?(field)
+    end
+
+    test "returns false if field doesn't have a phx-click handler" do
+      html = """
+      <label for="name">Name</label>
+      <input id="name" type="radio" name="name" value="Hello world"/>
+      """
+
+      field = Field.find_input!(html, "Name")
+
+      refute Field.phx_click?(field)
+    end
+  end
+
+  describe "belongs_to_form?" do
+    test "returns true if field is inside a form" do
+      html = """
+      <form>
+        <label for="name">Name</label>
+        <input id="name" type="text" name="name" value="Hello world"/>
+      </form>
+      """
+
+      field = Field.find_input!(html, "Name")
+
+      assert Field.belongs_to_form?(field)
+    end
+
+    test "returns false if field is outside of a form" do
+      html = """
+      <label for="name">Name</label>
+      <input id="name" type="text" name="name" value="Hello world"/>
+      """
+
+      field = Field.find_input!(html, "Name")
+
+      refute Field.belongs_to_form?(field)
+    end
+  end
 end

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -525,6 +525,23 @@ defmodule PhoenixTest.LiveTest do
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "contact: mail")
     end
+
+    test "works with a phx-click outside of a form", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#not-a-form", fn session ->
+        choose(session, "Huey")
+      end)
+      |> assert_has("#form-data", text: "value: huey")
+    end
+
+    test "raises an error if radio is neither in a form nor has a phx-click", %{conn: conn} do
+      session = visit(conn, "/live/index")
+
+      assert_raise ArgumentError, ~r/to have a `phx-click` attribute or belong to a `form` element/, fn ->
+        choose(session, "Invalid Radio Button")
+      end
+    end
   end
 
   describe "filling out full form with field functions" do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -247,6 +247,30 @@ defmodule PhoenixTest.IndexLive do
       <input id="email-on-change" name="email" />
     </form>
 
+    <div id="not-a-form">
+      <fieldset>
+        <legend>Select a maintenance drone:</legend>
+
+        <div>
+          <input phx-click="select-drone" type="radio" id="huey" name="drone" value="huey" checked />
+          <label for="huey">Huey</label>
+        </div>
+
+        <div>
+          <input phx-click="select-drone" type="radio" id="dewey" name="drone" value="dewey" />
+          <label for="dewey">Dewey</label>
+        </div>
+
+        <div>
+          <input phx-click="select-drone" type="radio" id="louie" name="drone" value="louie" />
+          <label for="louie">Louie</label>
+        </div>
+      </fieldset>
+    </div>
+
+    <label for="no-form-no-phx-click">Invalid Radio Button</label>
+    <input type="radio" id="no-form-no-phx-click" name="invalids" value="nothing" checked />
+
     <div id="hook" phx-hook="SomeHook"></div>
     <div id="hook-with-redirect" phx-hook="SomeOtherHook"></div>
     """
@@ -360,6 +384,15 @@ defmodule PhoenixTest.IndexLive do
 
   def handle_event("hook_with_redirect_event", _params, socket) do
     {:noreply, push_navigate(socket, to: "/live/page_2")}
+  end
+
+  def handle_event("select-drone", params, socket) do
+    {
+      :noreply,
+      socket
+      |> assign(:form_saved, true)
+      |> assign(:form_data, params)
+    }
   end
 
   defp render_input_data(key, value) when value == "" or is_nil(value) do


### PR DESCRIPTION
Part of https://github.com/germsvel/phoenix_test/issues/112

What changed?
============

We add the ability for radio buttons (i.e. `input type="radio"`) to live outside of forms in LiveViews.

Typically, people would want to add a `phx-click` to the radio button and rely on the input's `value` when it comes through the params.

Thus, we handle that specific case. We follow the pattern established in `click_button` to check:

1. If the input has a phx-click
2. If the input belongs to a form, or
3. Raise an error informing user that we expect the input to have one or the other

NOTE: we do not yet handle `phx-value-*` being passed. We might have to, but it seems that in radio buttons, that's unlikely to be the need. By default, Phoenix sends the input's `value`, so that's what we should rely on.

For our tests, we use the exact radio HTML found in MDN's documentation: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio