### PR TITLE
Allow select to work with phx-click

### DIFF
--- a/lib/phoenix_test/field.ex
+++ b/lib/phoenix_test/field.ex
@@ -27,52 +27,6 @@ defmodule PhoenixTest.Field do
     }
   end
 
-  def find_select_option!(html, label, option) do
-    field = Query.find_by_label!(html, label)
-    id = Html.attribute(field, "id")
-    name = Html.attribute(field, "name")
-
-    multiple = Html.attribute(field, "multiple") == "multiple"
-
-    value =
-      case {multiple, option} do
-        {true, [_ | _]} ->
-          Enum.map(option, fn opt ->
-            opt = Query.find!(Html.raw(field), "option", opt)
-            Html.attribute(opt, "value")
-          end)
-
-        {true, _} ->
-          option = Query.find!(Html.raw(field), "option", option)
-          [Html.attribute(option, "value")]
-
-        {false, [_ | _]} ->
-          msg = """
-          Could not find a select with a "multiple" attribute set.
-
-          Found the following select:
-
-          #{Html.raw(field)}
-          """
-
-          raise ArgumentError, msg
-
-        {false, _} ->
-          option = Query.find!(Html.raw(field), "option", option)
-          Html.attribute(option, "value")
-      end
-
-    %__MODULE__{
-      source_raw: html,
-      parsed: field,
-      label: label,
-      id: id,
-      name: name,
-      value: value,
-      selector: Element.build_selector(field)
-    }
-  end
-
   def find_checkbox!(html, label) do
     field = Query.find_by_label!(html, label)
     id = Html.attribute(field, "id")
@@ -107,14 +61,6 @@ defmodule PhoenixTest.Field do
       value: value,
       selector: Element.build_selector(field)
     }
-  end
-
-  def to_form_data(%{value: values} = field) when is_list(values) do
-    Enum.map(values, &{field.name, &1})
-  end
-
-  def to_form_data(field) do
-    [{field.name, field.value}]
   end
 
   def parent_form!(field) do

--- a/lib/phoenix_test/form_data.ex
+++ b/lib/phoenix_test/form_data.ex
@@ -1,0 +1,10 @@
+defmodule PhoenixTest.FormData do
+  @moduledoc false
+  def to_form_data(%{value: values} = field) when is_list(values) do
+    Enum.map(values, &{field.name, &1})
+  end
+
+  def to_form_data(field) do
+    [{field.name, field.value}]
+  end
+end

--- a/lib/phoenix_test/select.ex
+++ b/lib/phoenix_test/select.ex
@@ -1,0 +1,76 @@
+defmodule PhoenixTest.Select do
+  @moduledoc false
+
+  alias PhoenixTest.Element
+  alias PhoenixTest.Html
+  alias PhoenixTest.Query
+  alias PhoenixTest.Utils
+
+  @enforce_keys ~w[source_raw selected_options parsed label id name value selector]a
+  defstruct ~w[source_raw selected_options parsed label id name value selector]a
+
+  def find_select_option!(html, label, option) do
+    field = Query.find_by_label!(html, label)
+    id = Html.attribute(field, "id")
+    name = Html.attribute(field, "name")
+
+    multiple = Html.attribute(field, "multiple") == "multiple"
+
+    selected_options =
+      case {multiple, option} do
+        {true, [_ | _]} ->
+          Enum.map(option, fn opt ->
+            Query.find!(Html.raw(field), "option", opt)
+          end)
+
+        {true, _} ->
+          [Query.find!(Html.raw(field), "option", option)]
+
+        {false, [_ | _]} ->
+          msg = """
+          Could not find a select with a "multiple" attribute set.
+
+          Found the following select:
+
+          #{Html.raw(field)}
+          """
+
+          raise ArgumentError, msg
+
+        {false, _} ->
+          [field |> Html.raw() |> Query.find!("option", option)]
+      end
+
+    values = Enum.map(selected_options, fn option -> Html.attribute(option, "value") end)
+
+    %__MODULE__{
+      source_raw: html,
+      parsed: field,
+      label: label,
+      id: id,
+      name: name,
+      value: values,
+      selected_options: selected_options,
+      selector: Element.build_selector(field)
+    }
+  end
+
+  def phx_click_options?(field) do
+    Enum.all?(field.selected_options, fn option ->
+      option
+      |> Html.attribute("phx-click")
+      |> Utils.present?()
+    end)
+  end
+
+  def select_option_selector(field, value) do
+    field.selector <> " option[value=#{inspect(value)}]"
+  end
+
+  def belongs_to_form?(field) do
+    case Query.find_ancestor(field.source_raw, "form", field.selector) do
+      {:found, _} -> true
+      _ -> false
+    end
+  end
+end

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -8,10 +8,12 @@ defmodule PhoenixTest.Static do
   alias PhoenixTest.DataAttributeForm
   alias PhoenixTest.Field
   alias PhoenixTest.Form
+  alias PhoenixTest.FormData
   alias PhoenixTest.Html
   alias PhoenixTest.Link
   alias PhoenixTest.OpenBrowser
   alias PhoenixTest.Query
+  alias PhoenixTest.Select
 
   @endpoint Application.compile_env(:phoenix_test, :endpoint)
 
@@ -117,7 +119,7 @@ defmodule PhoenixTest.Static do
   def select(session, option, from: label) do
     session
     |> render_html()
-    |> Field.find_select_option!(label, option)
+    |> Select.find_select_option!(label, option)
     |> then(&fill_in_field_data(session, &1))
   end
 
@@ -145,7 +147,7 @@ defmodule PhoenixTest.Static do
   defp fill_in_field_data(session, field) do
     active_form = session.active_form
     existing_data = active_form.form_data
-    new_form_data = Field.to_form_data(field)
+    new_form_data = FormData.to_form_data(field)
 
     form = Field.parent_form!(field)
 

--- a/test/phoenix_test/field_test.exs
+++ b/test/phoenix_test/field_test.exs
@@ -71,54 +71,6 @@ defmodule PhoenixTest.FieldTest do
     end
   end
 
-  describe "find_select_option!" do
-    test "returns the selected option value" do
-      html = """
-      <label for="name">Name</label>
-      <select id="name" name="name">
-        <option value="select_1">Select 1</option>
-        <option value="select_2">Select 2</option>
-      </select>
-      """
-
-      field = Field.find_select_option!(html, "Name", "Select 2")
-
-      assert ~s|[id="name"]| = field.selector
-      assert "select_2" = field.value
-    end
-
-    test "returns multiple selected option value" do
-      html = """
-      <label for="name">Name</label>
-      <select multiple id="name" name="name">
-        <option value="select_1">Select 1</option>
-        <option value="select_2">Select 2</option>
-        <option value="select_3">Select 3</option>
-      </select>
-      """
-
-      field = Field.find_select_option!(html, "Name", ["Select 2", "Select 3"])
-
-      assert ~s|[id="name"]| = field.selector
-      assert ["select_2", "select_3"] = field.value
-    end
-
-    test "returns multiple selected option value without multiple attribute to select raises error" do
-      html = """
-      <label for="name">Name</label>
-      <select id="name" name="name">
-        <option value="select_1">Select 1</option>
-        <option value="select_2">Select 2</option>
-        <option value="select_3">Select 3</option>
-      </select>
-      """
-
-      assert_raise ArgumentError, ~r/Could not find a select with a "multiple" attribute set/, fn ->
-        Field.find_select_option!(html, "Name", ["Select 2", "Select 3"])
-      end
-    end
-  end
-
   describe "phx_click?" do
     test "returns true if field has a phx-click handler" do
       html = """

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -445,6 +445,32 @@ defmodule PhoenixTest.LiveTest do
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "[elf, dwarf]")
     end
+
+    test "works with phx-click outside of forms", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#not-a-form", fn session ->
+        select(session, "Dog", from: "Choose a pet:")
+      end)
+      |> assert_has("#form-data", text: "selected: [dog]")
+    end
+
+    test "works with phx-click and multi-select", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#not-a-form", fn session ->
+        select(session, ["Dog", "Cat"], from: "Choose a pet:")
+      end)
+      |> assert_has("#form-data", text: "selected: [dog, cat]")
+    end
+
+    test "raises an error if select option is neither in a form nor has a phx-click", %{conn: conn} do
+      session = visit(conn, "/live/index")
+
+      assert_raise ArgumentError, ~r/to have a `phx-click` attribute on options or to belong to a `form`/, fn ->
+        select(session, "Dog", from: "Invalid Select Option")
+      end
+    end
   end
 
   describe "check/2" do

--- a/test/phoenix_test/select_test.exs
+++ b/test/phoenix_test/select_test.exs
@@ -1,0 +1,113 @@
+defmodule PhoenixTest.SelectTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixTest.Select
+
+  describe "find_select_option!" do
+    test "returns the selected option value" do
+      html = """
+      <label for="name">Name</label>
+      <select id="name" name="name">
+        <option value="select_1">Select 1</option>
+        <option value="select_2">Select 2</option>
+      </select>
+      """
+
+      field = Select.find_select_option!(html, "Name", "Select 2")
+
+      assert ~s|[id="name"]| = field.selector
+      assert ["select_2"] = field.value
+    end
+
+    test "returns multiple selected option value" do
+      html = """
+      <label for="name">Name</label>
+      <select multiple id="name" name="name">
+        <option value="select_1">Select 1</option>
+        <option value="select_2">Select 2</option>
+        <option value="select_3">Select 3</option>
+      </select>
+      """
+
+      field = Select.find_select_option!(html, "Name", ["Select 2", "Select 3"])
+
+      assert ~s|[id="name"]| = field.selector
+      assert ["select_2", "select_3"] = field.value
+    end
+
+    test "returns multiple selected option value without multiple attribute to select raises error" do
+      html = """
+      <label for="name">Name</label>
+      <select id="name" name="name">
+        <option value="select_1">Select 1</option>
+        <option value="select_2">Select 2</option>
+        <option value="select_3">Select 3</option>
+      </select>
+      """
+
+      assert_raise ArgumentError, ~r/Could not find a select with a "multiple" attribute set/, fn ->
+        Select.find_select_option!(html, "Name", ["Select 2", "Select 3"])
+      end
+    end
+  end
+
+  describe "belongs_to_form?" do
+    test "returns true if field is inside a form" do
+      html = """
+      <form>
+        <label for="name">Name</label>
+        <select id="name" name="name">
+          <option value="select_1">Select 1</option>
+        </select>
+      </form>
+      """
+
+      field = Select.find_select_option!(html, "Name", "Select 1")
+
+      assert Select.belongs_to_form?(field)
+    end
+
+    test "returns false if field is outside of a form" do
+      html = """
+      <label for="name">Name</label>
+      <select id="name" name="name">
+        <option value="select_1">Select 1</option>
+      </select>
+      """
+
+      field = Select.find_select_option!(html, "Name", "Select 1")
+
+      refute Select.belongs_to_form?(field)
+    end
+  end
+
+  describe "phx_click_option?" do
+    test "returns true if all option have a phx-click attached" do
+      html = """
+      <label for="name">Name</label>
+      <select id="name" name="name">
+        <option phx-click="something" value="select_1">Select 1</option>
+        <option phx-click="something" value="select_2">Select 2</option>
+      </select>
+      """
+
+      field = Select.find_select_option!(html, "Name", "Select 2")
+
+      assert Select.phx_click_options?(field)
+    end
+
+    test "returns false if any option doesn't have e phx-click attached" do
+      html = """
+      <label for="name">Name</label>
+      <select multiple id="name" name="name">
+        <option phx-click="something" value="select_1">Select 1</option>
+        <option value="select_2">Select 2</option>
+      </select>
+      """
+
+      field = Select.find_select_option!(html, "Name", "Select 2")
+
+      refute Select.phx_click_options?(field)
+    end
+  end
+end

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -266,10 +266,21 @@ defmodule PhoenixTest.IndexLive do
           <label for="louie">Louie</label>
         </div>
       </fieldset>
+
+      <label for="pet-select">Choose a pet:</label>
+      <select multiple name="pets" id="pet-select">
+        <option phx-click="select-pet" value="dog">Dog</option>
+        <option phx-click="select-pet" value="cat">Cat</option>
+      </select>
     </div>
 
     <label for="no-form-no-phx-click">Invalid Radio Button</label>
     <input type="radio" id="no-form-no-phx-click" name="invalids" value="nothing" checked />
+
+    <label for="no-form-no-phx-click-select">Invalid Select Option</label>
+    <select name="pets" id="no-form-no-phx-click-select">
+      <option value="dog">Dog</option>
+    </select>
 
     <div id="hook" phx-hook="SomeHook"></div>
     <div id="hook-with-redirect" phx-hook="SomeOtherHook"></div>
@@ -354,6 +365,19 @@ defmodule PhoenixTest.IndexLive do
 
   def handle_event("select-city", %{"city" => city}, socket) do
     form_data = %{socket.assigns[:country] => city}
+
+    socket
+    |> assign(:form_saved, true)
+    |> assign(:form_data, form_data)
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_event("select-pet", %{"value" => value}, socket) do
+    form_data =
+      case socket.assigns.form_data do
+        %{selected: values} -> %{selected: values ++ [value]}
+        %{} -> %{selected: [value]}
+      end
 
     socket
     |> assign(:form_saved, true)


### PR DESCRIPTION
Part of https://github.com/germsvel/phoenix_test/issues/112

What changed?
============

We update the `select` helper to work with `phx-click` outside of forms.

Note that the `phx-click` has to be on the option being selected, not on the `select` tag itself.

For multi-selects, we trigger a `phx-click` for each option selected. That emulates how Phoenix receives events from the browser with multi-select.

Restructuring
-------------

As part of this work, we extract a `Select` module to keep all the select logic. Now `Field` could probably be renamed `Input`, since it's dealing with inputs (text, radio, checkbox).

Finally, we move the `Field.to_form_data` function into a `FormData` module. We originally though to make it a protocol, but it seems overkill. For now, pattern matching just like we had in `Field` will do.