### PR TITLE
Check/uncheck work with phx-click outside forms

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -506,6 +506,23 @@ defmodule PhoenixTest.LiveTest do
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:payer: on")
     end
+
+    test "works with phx-click outside a form", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#not-a-form", fn session ->
+        check(session, "Second Breakfast")
+      end)
+      |> assert_has("#form-data", text: "value: second-breakfast")
+    end
+
+    test "raises error if checkbox doesn't have phx-click or belong to form", %{conn: conn} do
+      session = visit(conn, "/live/index")
+
+      assert_raise ArgumentError, ~r/have a `phx-click` attribute or belong to a `form`/, fn ->
+        check(session, "Invalid Checkbox")
+      end
+    end
   end
 
   describe "uncheck/2" do
@@ -533,6 +550,25 @@ defmodule PhoenixTest.LiveTest do
       |> uncheck("Payer")
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:payer: off")
+    end
+
+    test "works with phx-click outside a form", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#not-a-form", fn session ->
+        session
+        |> check("Second Breakfast")
+        |> uncheck("Second Breakfast")
+      end)
+      |> refute_has("#form-data", text: "value: second-breakfast")
+    end
+
+    test "raises error if checkbox doesn't have phx-click or belong to form", %{conn: conn} do
+      session = visit(conn, "/live/index")
+
+      assert_raise ArgumentError, ~r/have a `phx-click` attribute or belong to a `form`/, fn ->
+        uncheck(session, "Invalid Checkbox")
+      end
     end
   end
 

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -272,6 +272,21 @@ defmodule PhoenixTest.IndexLive do
         <option phx-click="select-pet" value="dog">Dog</option>
         <option phx-click="select-pet" value="cat">Cat</option>
       </select>
+
+      <fieldset>
+        <legend>Select to get second breakfast:</legend>
+
+        <div>
+          <input
+            phx-click="toggle-second-breakfast"
+            type="checkbox"
+            id="second-breakfast"
+            name="second-breakfast"
+            value="second-breakfast"
+          />
+          <label for="second-breakfast">Second Breakfast</label>
+        </div>
+      </fieldset>
     </div>
 
     <label for="no-form-no-phx-click">Invalid Radio Button</label>
@@ -281,6 +296,9 @@ defmodule PhoenixTest.IndexLive do
     <select name="pets" id="no-form-no-phx-click-select">
       <option value="dog">Dog</option>
     </select>
+
+    <label for="no-form-no-phx-click-checkbox">Invalid Checkbox</label>
+    <input type="checkbox" id="no-form-no-phx-click-checkbox" name="no-breakfast" />
 
     <div id="hook" phx-hook="SomeHook"></div>
     <div id="hook-with-redirect" phx-hook="SomeOtherHook"></div>
@@ -382,6 +400,13 @@ defmodule PhoenixTest.IndexLive do
     socket
     |> assign(:form_saved, true)
     |> assign(:form_data, form_data)
+    |> then(&{:noreply, &1})
+  end
+
+  def handle_event("toggle-second-breakfast", params, socket) do
+    socket
+    |> assign(:form_saved, true)
+    |> assign(:form_data, params)
     |> then(&{:noreply, &1})
   end
 


### PR DESCRIPTION
Supersedes https://github.com/germsvel/phoenix_test/pull/109 
Resolves https://github.com/germsvel/phoenix_test/issues/112

What changed?
=============

We update `check` and `uncheck` to work with `phx-click` attributes
outside of forms.

The `check` case is straightforward. The `uncheck` is more complicated.

For the `uncheck` case, we first look for an checkbox that is visible.
That's contrary to what we were doing with form checkboxes -- where we
need a hidden input -- because a single checkbox can have a `phx-click`
for checking and unchecking. That removes the need for the hidden input
(like forms need).

So, if we find the checkbox and it has a `phx-click` attached, we
trigger that. If not, we check if the field belongs to a form. If so, we
find the hidden "uncheckbox" to get the value.

Then, we run into the problem that Phoenix's `phx-click` behavior on a
checkbox outside of a form makes sense but `render_click` behaves
differently:

- If a checkbox is getting checked, the `value` is included in the
  params
- If a checkbox is getting un-checked, the `value` is not included in
  the params (i.e. we get an empty map)

But `view |> element |> render_click` always includes the `value` of the
element in the payload. To bypass that, we have to avoid using the
`element` helper and directly send the event to `render_click/3` along
with an empty map for a payload.