### PR TITLE
Find select option via 'exact=true' (breaking change)

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -495,6 +495,12 @@ defmodule PhoenixTest do
   @doc """
   Selects an option from a select dropdown.
 
+  ## Options
+
+  - `exact`: by default `select/3` will find the option by exact label match.
+  If you want to find an option by substring, use `exact: false`.
+  (defaults to `true`)
+
   ## Inside a form
 
   If the form is a LiveView form, and if the form has a `phx-change` attribute
@@ -514,6 +520,7 @@ defmodule PhoenixTest do
       <option value="elf">Elf</option>
       <option value="dwarf">Dwarf</option>
       <option value="orc">Orc</option>
+      <option value="other_orc">Other Orc</option>
     </select>
   </form>
   ```
@@ -523,6 +530,7 @@ defmodule PhoenixTest do
   ```elixir
   session
   |> select("Human", from: "Race")
+  |> select("Other", from: "Race", exact: false)
   ```
 
   ## Outside a form

--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -495,12 +495,6 @@ defmodule PhoenixTest do
   @doc """
   Selects an option from a select dropdown.
 
-  ## Options
-
-  - `exact`: by default `select/3` will find the option via a substring match (e.g. `a
-  =~ b`). But sometimes we want need to disambiguate options that have a common substring.
-  For that, use `exact: true`. (defaults to `false`)
-
   ## Inside a form
 
   If the form is a LiveView form, and if the form has a `phx-change` attribute
@@ -520,7 +514,6 @@ defmodule PhoenixTest do
       <option value="elf">Elf</option>
       <option value="dwarf">Dwarf</option>
       <option value="orc">Orc</option>
-      <option value="other_orc">Other Orc</option>
     </select>
   </form>
   ```
@@ -530,7 +523,6 @@ defmodule PhoenixTest do
   ```elixir
   session
   |> select("Human", from: "Race")
-  |> select("Orc", from: "Race", exact: true)
   ```
 
   ## Outside a form

--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -495,6 +495,12 @@ defmodule PhoenixTest do
   @doc """
   Selects an option from a select dropdown.
 
+  ## Options
+
+  - `exact`: by default `select/3` will find the option via a substring match (e.g. `a
+  =~ b`). But sometimes we want need to disambiguate options that have a common substring.
+  For that, use `exact: true`. (defaults to `false`)
+
   ## Inside a form
 
   If the form is a LiveView form, and if the form has a `phx-change` attribute
@@ -514,6 +520,7 @@ defmodule PhoenixTest do
       <option value="elf">Elf</option>
       <option value="dwarf">Dwarf</option>
       <option value="orc">Orc</option>
+      <option value="other_orc">Other Orc</option>
     </select>
   </form>
   ```
@@ -523,6 +530,7 @@ defmodule PhoenixTest do
   ```elixir
   session
   |> select("Human", from: "Race")
+  |> select("Orc", from: "Race", exact: true)
   ```
 
   ## Outside a form

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -101,7 +101,9 @@ defmodule PhoenixTest.Live do
     |> then(&fill_in_field_data(session, &1))
   end
 
-  def select(session, option, [{:from, label} | opts]) do
+  def select(session, option, opts) do
+    label = Keyword.fetch!(opts, :from)
+
     field =
       session
       |> render_html()

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -101,11 +101,11 @@ defmodule PhoenixTest.Live do
     |> then(&fill_in_field_data(session, &1))
   end
 
-  def select(session, option, from: label) do
+  def select(session, option, [{:from, label} | opts]) do
     field =
       session
       |> render_html()
-      |> Select.find_select_option!(label, option)
+      |> Select.find_select_option!(label, option, opts)
 
     cond do
       Select.belongs_to_form?(field) ->

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -101,11 +101,11 @@ defmodule PhoenixTest.Live do
     |> then(&fill_in_field_data(session, &1))
   end
 
-  def select(session, option, [{:from, label} | opts]) do
+  def select(session, option, from: label) do
     field =
       session
       |> render_html()
-      |> Select.find_select_option!(label, option, opts)
+      |> Select.find_select_option!(label, option)
 
     cond do
       Select.belongs_to_form?(field) ->

--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -51,8 +51,8 @@ defmodule PhoenixTest.Query do
 
   Raises `ArgumentError` if no element is found with the given selector or if multiple elements are found.
   """
-  def find!(html, selector, text) do
-    case find(html, selector, text) do
+  def find!(html, selector, text, opts \\ []) do
+    case find(html, selector, text, opts) do
       {:not_found, elements} ->
         msg =
           if Enum.any?(elements) do

--- a/lib/phoenix_test/select.ex
+++ b/lib/phoenix_test/select.ex
@@ -9,7 +9,7 @@ defmodule PhoenixTest.Select do
   @enforce_keys ~w[source_raw selected_options parsed label id name value selector]a
   defstruct ~w[source_raw selected_options parsed label id name value selector]a
 
-  def find_select_option!(html, label, option) do
+  def find_select_option!(html, label, option, opts \\ []) do
     field = Query.find_by_label!(html, "select", label)
     id = Html.attribute(field, "id")
     name = Html.attribute(field, "name")
@@ -20,11 +20,11 @@ defmodule PhoenixTest.Select do
       case {multiple, option} do
         {true, [_ | _]} ->
           Enum.map(option, fn opt ->
-            Query.find!(Html.raw(field), "option", opt)
+            Query.find!(Html.raw(field), "option", opt, opts)
           end)
 
         {true, _} ->
-          [Query.find!(Html.raw(field), "option", option)]
+          [Query.find!(Html.raw(field), "option", option, opts)]
 
         {false, [_ | _]} ->
           msg = """
@@ -38,7 +38,7 @@ defmodule PhoenixTest.Select do
           raise ArgumentError, msg
 
         {false, _} ->
-          [field |> Html.raw() |> Query.find!("option", option)]
+          [field |> Html.raw() |> Query.find!("option", option, opts)]
       end
 
     values = Enum.map(selected_options, fn option -> Html.attribute(option, "value") end)

--- a/lib/phoenix_test/select.ex
+++ b/lib/phoenix_test/select.ex
@@ -9,7 +9,8 @@ defmodule PhoenixTest.Select do
   @enforce_keys ~w[source_raw selected_options parsed label id name value selector]a
   defstruct ~w[source_raw selected_options parsed label id name value selector]a
 
-  def find_select_option!(html, label, option) do
+  def find_select_option!(html, label, option, opts \\ []) do
+    opts = Keyword.put_new(opts, :exact, true)
     field = Query.find_by_label!(html, "select", label)
     id = Html.attribute(field, "id")
     name = Html.attribute(field, "name")
@@ -20,11 +21,11 @@ defmodule PhoenixTest.Select do
       case {multiple, option} do
         {true, [_ | _]} ->
           Enum.map(option, fn opt ->
-            Query.find!(Html.raw(field), "option", opt, exact: true)
+            Query.find!(Html.raw(field), "option", opt, opts)
           end)
 
         {true, _} ->
-          [Query.find!(Html.raw(field), "option", option, exact: true)]
+          [Query.find!(Html.raw(field), "option", option, opts)]
 
         {false, [_ | _]} ->
           msg = """
@@ -38,7 +39,7 @@ defmodule PhoenixTest.Select do
           raise ArgumentError, msg
 
         {false, _} ->
-          [field |> Html.raw() |> Query.find!("option", option, exact: true)]
+          [field |> Html.raw() |> Query.find!("option", option, opts)]
       end
 
     values = Enum.map(selected_options, fn option -> Html.attribute(option, "value") end)

--- a/lib/phoenix_test/select.ex
+++ b/lib/phoenix_test/select.ex
@@ -9,7 +9,7 @@ defmodule PhoenixTest.Select do
   @enforce_keys ~w[source_raw selected_options parsed label id name value selector]a
   defstruct ~w[source_raw selected_options parsed label id name value selector]a
 
-  def find_select_option!(html, label, option, opts \\ []) do
+  def find_select_option!(html, label, option) do
     field = Query.find_by_label!(html, "select", label)
     id = Html.attribute(field, "id")
     name = Html.attribute(field, "name")
@@ -20,11 +20,11 @@ defmodule PhoenixTest.Select do
       case {multiple, option} do
         {true, [_ | _]} ->
           Enum.map(option, fn opt ->
-            Query.find!(Html.raw(field), "option", opt, opts)
+            Query.find!(Html.raw(field), "option", opt, exact: true)
           end)
 
         {true, _} ->
-          [Query.find!(Html.raw(field), "option", option, opts)]
+          [Query.find!(Html.raw(field), "option", option, exact: true)]
 
         {false, [_ | _]} ->
           msg = """
@@ -38,7 +38,7 @@ defmodule PhoenixTest.Select do
           raise ArgumentError, msg
 
         {false, _} ->
-          [field |> Html.raw() |> Query.find!("option", option, opts)]
+          [field |> Html.raw() |> Query.find!("option", option, exact: true)]
       end
 
     values = Enum.map(selected_options, fn option -> Html.attribute(option, "value") end)

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -117,10 +117,10 @@ defmodule PhoenixTest.Static do
     |> then(&fill_in_field_data(session, &1))
   end
 
-  def select(session, option, [{:from, label} | opts]) do
+  def select(session, option, from: label) do
     session
     |> render_html()
-    |> Select.find_select_option!(label, option, opts)
+    |> Select.find_select_option!(label, option)
     |> then(&fill_in_field_data(session, &1))
   end
 

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -117,7 +117,9 @@ defmodule PhoenixTest.Static do
     |> then(&fill_in_field_data(session, &1))
   end
 
-  def select(session, option, [{:from, label} | opts]) do
+  def select(session, option, opts) do
+    label = Keyword.fetch!(opts, :from)
+
     session
     |> render_html()
     |> Select.find_select_option!(label, option, opts)

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -117,10 +117,10 @@ defmodule PhoenixTest.Static do
     |> then(&fill_in_field_data(session, &1))
   end
 
-  def select(session, option, from: label) do
+  def select(session, option, [{:from, label} | opts]) do
     session
     |> render_html()
-    |> Select.find_select_option!(label, option)
+    |> Select.find_select_option!(label, option, opts)
     |> then(&fill_in_field_data(session, &1))
   end
 

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -428,6 +428,15 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#full-form option[value='elf']")
     end
 
+    test "'exact: false' raises error if similar option exists", %{conn: conn} do
+      assert_raise ArgumentError, ~r/Found more than one element/, fn ->
+        conn
+        |> visit("/live/index")
+        |> select("Orc", from: "Race", exact: false)
+        |> assert_has("#full-form option[value='orc']")
+      end
+    end
+
     test "allows selecting option if a similar option exists", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -424,8 +424,24 @@ defmodule PhoenixTest.LiveTest do
     test "selects given option for a label", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("Elf", from: "Race")
+      |> select("Elf", from: "Race", exact: true)
       |> assert_has("#full-form option[value='elf']")
+    end
+
+    test "option fails to be selected if similar option exists", %{conn: conn} do
+      assert_raise ArgumentError, ~r/Found more than one element/, fn ->
+        conn
+        |> visit("/live/index")
+        |> select("Orc", from: "Race")
+        |> assert_has("#full-form option[value='orc']")
+      end
+    end
+
+    test "exact=true allows selecting option if a similar option exists", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> select("Orc", from: "Race", exact: true)
+      |> assert_has("#full-form option[value='orc']")
     end
 
     test "works in 'nested' forms", %{conn: conn} do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -424,23 +424,14 @@ defmodule PhoenixTest.LiveTest do
     test "selects given option for a label", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("Elf", from: "Race", exact: true)
+      |> select("Elf", from: "Race")
       |> assert_has("#full-form option[value='elf']")
     end
 
-    test "option fails to be selected if similar option exists", %{conn: conn} do
-      assert_raise ArgumentError, ~r/Found more than one element/, fn ->
-        conn
-        |> visit("/live/index")
-        |> select("Orc", from: "Race")
-        |> assert_has("#full-form option[value='orc']")
-      end
-    end
-
-    test "exact=true allows selecting option if a similar option exists", %{conn: conn} do
+    test "allows selecting option if a similar option exists", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("Orc", from: "Race", exact: true)
+      |> select("Orc", from: "Race")
       |> assert_has("#full-form option[value='orc']")
     end
 

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -432,6 +432,15 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("#full-form option[value='orc']")
     end
 
+    test "'exact: false' raises error if similar option exists", %{conn: conn} do
+      assert_raise ArgumentError, ~r/Found more than one element/, fn ->
+        conn
+        |> visit("/page/index")
+        |> select("Orc", from: "Race", exact: false)
+        |> assert_has("#full-form option[value='orc']")
+      end
+    end
+
     test "works in 'nested' forms", %{conn: conn} do
       conn
       |> visit("/page/index")

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -425,19 +425,10 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("#form-data", text: "race: human")
     end
 
-    test "option fails to be selected if similar option exists", %{conn: conn} do
-      assert_raise ArgumentError, ~r/Found more than one element/, fn ->
-        conn
-        |> visit("/page/index")
-        |> select("Orc", from: "Race")
-        |> assert_has("#full-form option[value='orc']")
-      end
-    end
-
-    test "exact=true allows selecting option if a similar option exists", %{conn: conn} do
+    test "allows selecting option if a similar option exists", %{conn: conn} do
       conn
       |> visit("/page/index")
-      |> select("Orc", from: "Race", exact: true)
+      |> select("Orc", from: "Race")
       |> assert_has("#full-form option[value='orc']")
     end
 

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -425,6 +425,22 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("#form-data", text: "race: human")
     end
 
+    test "option fails to be selected if similar option exists", %{conn: conn} do
+      assert_raise ArgumentError, ~r/Found more than one element/, fn ->
+        conn
+        |> visit("/page/index")
+        |> select("Orc", from: "Race")
+        |> assert_has("#full-form option[value='orc']")
+      end
+    end
+
+    test "exact=true allows selecting option if a similar option exists", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> select("Orc", from: "Race", exact: true)
+      |> assert_has("#full-form option[value='orc']")
+    end
+
     test "works in 'nested' forms", %{conn: conn} do
       conn
       |> visit("/page/index")

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -151,6 +151,7 @@ defmodule PhoenixTest.IndexLive do
         <option value="elf">Elf</option>
         <option value="dwarf">Dwarf</option>
         <option value="orc">Orc</option>
+        <option value="other_orc">Other Orc</option>
       </select>
 
       <label for="race_2">Race 2</label>

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -176,6 +176,7 @@ defmodule PhoenixTest.PageView do
         <option value="elf">Elf</option>
         <option value="dwarf">Dwarf</option>
         <option value="orc">Orc</option>
+        <option value="other_orc">Other Orc</option>
       </select>
 
       <label for="race_2">Race 2</label>


### PR DESCRIPTION
Find select option by exact match. Allows disambiguating options that share a common substring.

E.g.
```html
<select>
  <option value="orc">Orc</option>
  <option value="other_orc">Other Orc</option>
</select>
```

Currently, there is no way to distinguish `Orc` and `Other Orc` (`Found more than one element`).