### PR TITLE
Fix: Don't error on input without name attribute

### DIFF
--- a/lib/phoenix_test/form.ex
+++ b/lib/phoenix_test/form.ex
@@ -91,14 +91,17 @@ defmodule PhoenixTest.Form do
   @pre_filled_default_text_inputs "input:not([disabled]):not([type])[value]"
 
   defp form_data(form) do
-    form_data(@hidden_inputs, form) ++
-      form_data(@checked_radio_buttons, form) ++
-      form_data(@checked_checkboxes, form) ++
-      form_data(@pre_filled_text_inputs, form) ++
-      form_data(@pre_filled_number_inputs, form) ++
-      form_data(@pre_filled_default_text_inputs, form) ++
-      form_data_textarea(form) ++
-      form_data_select(form)
+    Enum.reject(
+      form_data(@hidden_inputs, form) ++
+        form_data(@checked_radio_buttons, form) ++
+        form_data(@checked_checkboxes, form) ++
+        form_data(@pre_filled_text_inputs, form) ++
+        form_data(@pre_filled_number_inputs, form) ++
+        form_data(@pre_filled_default_text_inputs, form) ++
+        form_data_textarea(form) ++
+        form_data_select(form),
+      fn {key, _value} -> is_nil(key) end
+    )
   end
 
   defp form_data(selector, form) do

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -213,6 +213,10 @@ defmodule PhoenixTest.PageView do
         <input type="checkbox" name="member_of_fellowship" />
       </div>
 
+      <label>
+        Ignored presentational input input <input value="123" />
+      </label>
+
       <button name="full_form_button" value="save">Save Full Form</button>
     </form>
 


### PR DESCRIPTION
Given

```html
<input value="123" />
```

submit the form without error.
Just omit the input without a name attribute.
