### PR TITLE
Ignore `phx-*` attrs when inferring selector

### DIFF
--- a/lib/phoenix_test/element.ex
+++ b/lib/phoenix_test/element.ex
@@ -4,6 +4,7 @@ defmodule PhoenixTest.Element do
   def build_selector({tag, attributes, _}) do
     Enum.reduce_while(attributes, tag, fn
       {"id", id}, _ when is_binary(id) -> {:halt, "[id=#{inspect(id)}]"}
+      {"phx-" <> _rest, _}, acc -> {:cont, acc}
       {"class", _}, acc -> {:cont, acc}
       {k, v}, acc -> {:cont, acc <> "[#{k}=#{inspect(v)}]"}
     end)

--- a/test/phoenix_test/element_test.exs
+++ b/test/phoenix_test/element_test.exs
@@ -32,5 +32,19 @@ defmodule PhoenixTest.ElementTest do
 
       assert ~s(input[type="text"][name="name"]) = selector
     end
+
+    test "ignores `phx-*` attributes when id isn't present" do
+      data =
+        Query.find!(
+          """
+          <input phx-click="ignore-complex-liveview-js" type="text" name="name" />
+          """,
+          "input"
+        )
+
+      selector = Element.build_selector(data)
+
+      assert ~s(input[type="text"][name="name"]) = selector
+    end
   end
 end


### PR DESCRIPTION
Closes https://github.com/germsvel/phoenix_test/pull/124

What changed?
=============

When we build elements, we infer their selector based on `id` or all of their other attributes.

Up until now, we grabbed everything expect the `class`. But `phx-*` attributes can also have complex data when they're `LiveView.JS` actions. So, we should ignore that too when creating the selector.