### PR TITLE
🛠️ Select options are always exact

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -560,7 +560,6 @@ defmodule PhoenixTest do
       <option value="elf">Elf</option>
       <option value="dwarf">Dwarf</option>
       <option value="orc">Orc</option>
-      <option value="other_orc">Other Orc</option>
     </select>
   </form>
   ```
@@ -570,7 +569,6 @@ defmodule PhoenixTest do
   ```elixir
   session
   |> select("Human", from: "Race")
-  |> select("Other", from: "Race", exact: false)
   ```
 
   ## Outside a form
@@ -606,10 +604,6 @@ defmodule PhoenixTest do
   ## Options
 
   - `from` (required): the label of the select dropdown.
-
-  - `exact`: by default `select/3` will find the option by exact label match.
-  If you want to find an option by substring, use `exact: false`.
-  (defaults to `true`)
   """
   def select(session, option, attrs) do
     opts = Keyword.validate!(attrs, [:from, exact: true])

--- a/lib/phoenix_test/select.ex
+++ b/lib/phoenix_test/select.ex
@@ -20,11 +20,11 @@ defmodule PhoenixTest.Select do
       case {multiple, option} do
         {true, [_ | _]} ->
           Enum.map(option, fn opt ->
-            Query.find!(Html.raw(field), "option", opt, opts)
+            Query.find!(Html.raw(field), "option", opt, exact: true)
           end)
 
         {true, _} ->
-          [Query.find!(Html.raw(field), "option", option, opts)]
+          [Query.find!(Html.raw(field), "option", option, exact: true)]
 
         {false, [_ | _]} ->
           msg = """
@@ -38,7 +38,7 @@ defmodule PhoenixTest.Select do
           raise ArgumentError, msg
 
         {false, _} ->
-          [field |> Html.raw() |> Query.find!("option", option, opts)]
+          [field |> Html.raw() |> Query.find!("option", option, exact: true)]
       end
 
     values = Enum.map(selected_options, fn option -> Html.attribute(option, "value") end)

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -437,15 +437,6 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#full-form option[value='elf']")
     end
 
-    test "'exact: false' raises error if similar option exists", %{conn: conn} do
-      assert_raise ArgumentError, ~r/Found many elements/, fn ->
-        conn
-        |> visit("/live/index")
-        |> select("Orc", from: "Race", exact: false)
-        |> assert_has("#full-form option[value='orc']")
-      end
-    end
-
     test "allows selecting option if a similar option exists", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -442,15 +442,6 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("#full-form option[value='orc']")
     end
 
-    test "'exact: false' raises error if similar option exists", %{conn: conn} do
-      assert_raise ArgumentError, ~r/Found many elements/, fn ->
-        conn
-        |> visit("/page/index")
-        |> select("Orc", from: "Race", exact: false)
-        |> assert_has("#full-form option[value='orc']")
-      end
-    end
-
     test "works in 'nested' forms", %{conn: conn} do
       conn
       |> visit("/page/index")


### PR DESCRIPTION
What changed?
=============

PR #118 (commit dc7ba01) introduced the ability to pass `exact: true | false` to `select`.

That need arose because we were doing substring matches in select options. So, if a form had the following two options:

```html
<option value="orc">Orc</option>
<option value="other_orc">Other Orc</option>
```

there was no way to distinguish between them!

To provide backwards compatibility, I suggested we include the ability to pass the `exact: false` option. But I now think that was a bad suggestion.

It seems to me that options should always be exact, and the previous implementation was basically a bug.

Why not leave the `:exact` option just in case?
----------------------------------------------

[Other work](https://github.com/germsvel/phoenix_test/issues/127) is introducing the ability to target labels with `exact: true | false`. The `select` function is the only one where we need to distinguish between an exact label and exact option. So, we were going to change the option to `:exact_option`. But really, options should _always_ be exact.

Unlike labels, `<option>` elements tend to have simple text inside them -- and as seen by the issue in PR #118, it makes little sense for the option to be inexact.

Labels, on the other hand, can have more complex nested HTML inside them (e.g. some `<span>*</span>` for required attrs). Thus, it's nice to be able to target the label inexactly (with substring matches).

Thankfully, we haven't released this work yet, so we can change it freely without fear of someone already relying on `exact: false`. Of course, since we're going to make options always exact, there's a possibility of a breaking change. We'll note that clearly in the release notes.