### PR TITLE
✨ Form helpers now take `:exact` option

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -399,6 +399,15 @@ defmodule PhoenixTest.LiveTest do
       |> refute_has("#form-data", text: "email: frodo@example.com")
     end
 
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#complex-labels", fn session ->
+        fill_in(session, "Name", with: "Frodo", exact: false)
+      end)
+      |> assert_has("#form-data", text: "name: Frodo")
+    end
+
     test "can target input with selector if multiple labels have same text", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -487,6 +496,15 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "selected: [dog, cat]")
     end
 
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#complex-labels", fn session ->
+        select(session, "Dog", from: "Choose a pet:", exact: false)
+      end)
+      |> assert_has("#form-data", text: "pet: dog")
+    end
+
     test "can target option with selector if multiple labels have same text", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -548,6 +566,15 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "value: second-breakfast")
     end
 
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#complex-labels", fn session ->
+        check(session, "Human", exact: false)
+      end)
+      |> assert_has("#form-data", text: "human: yes")
+    end
+
     test "can specify input selector when multiple checkboxes have same label", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -604,6 +631,17 @@ defmodule PhoenixTest.LiveTest do
       |> refute_has("#form-data", text: "value: second-breakfast")
     end
 
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#complex-labels", fn session ->
+        session
+        |> check("Human", exact: false)
+        |> uncheck("Human", exact: false)
+      end)
+      |> assert_has("#form-data", text: "human: no")
+    end
+
     test "can specify input selector when multiple checkboxes have same label", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -650,6 +688,15 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "value: huey")
     end
 
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#complex-labels", fn session ->
+        choose(session, "Book", exact: false)
+      end)
+      |> assert_has("#form-data", text: "book-or-movie: book")
+    end
+
     test "can specify input selector when multiple options have same label in same form", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -676,6 +723,17 @@ defmodule PhoenixTest.LiveTest do
         session
         |> upload("Avatar", "test/files/elixir.jpg")
         |> click_button("Save Full Form")
+      end)
+      |> assert_has("#form-data", text: "avatar: elixir.jpg")
+    end
+
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#complex-labels", fn session ->
+        session
+        |> upload("Avatar", "test/files/elixir.jpg", exact: false)
+        |> click_button("Save")
       end)
       |> assert_has("#form-data", text: "avatar: elixir.jpg")
     end

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -388,6 +388,16 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("#form-data", text: "user:name: Legolas")
     end
 
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> within("#complex-labels", fn session ->
+        fill_in(session, "Name", with: "Frodo", exact: false)
+      end)
+      |> submit()
+      |> assert_has("#form-data", text: "name: Frodo")
+    end
+
     test "can target input with selector if multiple labels have same text", %{conn: conn} do
       conn
       |> visit("/page/index")
@@ -465,6 +475,16 @@ defmodule PhoenixTest.StaticTest do
       |> refute_has("#form-data", text: "race_2")
     end
 
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> within("#complex-labels", fn session ->
+        select(session, "Dog", from: "Choose a pet:", exact: false)
+      end)
+      |> submit()
+      |> assert_has("#form-data", text: "pet: dog")
+    end
+
     test "can target option with selector if multiple labels have same text", %{conn: conn} do
       conn
       |> visit("/page/index")
@@ -510,6 +530,16 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("#form-data", text: "subscribe?: on")
     end
 
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> within("#complex-labels", fn session ->
+        check(session, "Human", exact: false)
+      end)
+      |> submit()
+      |> assert_has("#form-data", text: "human: yes")
+    end
+
     test "can specify input selector when multiple checkboxes have same label", %{conn: conn} do
       conn
       |> visit("/page/index")
@@ -537,6 +567,18 @@ defmodule PhoenixTest.StaticTest do
       |> uncheck("Admin")
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "admin: off")
+    end
+
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> within("#complex-labels", fn session ->
+        session
+        |> check("Human", exact: false)
+        |> uncheck("Human", exact: false)
+      end)
+      |> submit()
+      |> assert_has("#form-data", text: "human: no")
     end
 
     test "can specify input selector when multiple checkboxes have same label", %{conn: conn} do
@@ -567,6 +609,16 @@ defmodule PhoenixTest.StaticTest do
       |> visit("/page/index")
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "contact: mail")
+    end
+
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> within("#complex-labels", fn session ->
+        choose(session, "Book", exact: false)
+      end)
+      |> submit()
+      |> assert_has("#form-data", text: "book-or-movie: book")
     end
 
     test "can specify input selector when multiple options have same label in same form", %{conn: conn} do
@@ -609,6 +661,17 @@ defmodule PhoenixTest.StaticTest do
       |> upload("Nested Avatar", "test/files/elixir.jpg")
       |> click_button("Save File upload Form")
       |> assert_has("#form-data", text: "user:avatar: elixir.jpg")
+    end
+
+    test "can target a label with exact: false", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> within("#complex-labels", fn session ->
+        session
+        |> upload("Avatar", "test/files/elixir.jpg", exact: false)
+        |> click_button("Save")
+      end)
+      |> assert_has("#form-data", text: "avatar: elixir.jpg")
     end
 
     test "can specify input selector when multiple inputs have same label", %{conn: conn} do

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -255,6 +255,40 @@ defmodule PhoenixTest.IndexLive do
       <input id="email-on-change" name="email" />
     </form>
 
+    <form id="complex-labels" phx-change="save-form" phx-submit="save-form">
+      <label for="complex-name">
+        Name <span>*</span>
+      </label>
+      <input id="complex-name" name="name" />
+
+      <label for="complex-human">
+        Human <span>*</span>
+      </label>
+      <input type="hidden" name="human" value="no" />
+      <input type="checkbox" id="complex-human" name="human" value="yes" />
+
+      <label for="complex-animals">Choose a pet: <span>*</span></label>
+      <select id="complex-animals" name="pet">
+        <option value="dog">Dog</option>
+        <option value="cat">Cat</option>
+      </select>
+
+      <fieldset>
+        <legend>Book or movie?</legend>
+
+        <input type="radio" id="complex-book" name="book-or-movie" value="book" />
+        <label for="complex-book">Book <span>*</span></label>
+
+        <input type="radio" id="complex-movie" name="book-or-movie" value="movie" />
+        <label for="complex-movie">Movie <span>*</span></label>
+      </fieldset>
+
+      <label for={@uploads.avatar.ref}>Avatar <span>*</span></label>
+      <.live_file_input upload={@uploads.avatar} />
+
+      <button type="submit">Save</button>
+    </form>
+
     <form id="same-labels" phx-submit="save-form" phx-change="save-form">
       <fieldset name="like-elixir">
         <legend>Do you like Elixir:</legend>
@@ -268,6 +302,7 @@ defmodule PhoenixTest.IndexLive do
           <label for="elixir-no">No</label>
         </div>
       </fieldset>
+
       <fieldset>
         <legend>Do you like Erlang:</legend>
 

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -270,7 +270,41 @@ defmodule PhoenixTest.PageView do
     </form>
     <button form="owner-form">Save Owner Form</button>
 
-    <form action="/page/create_record" method="post" id="same-labels">
+    <form id="complex-labels" method="post" action="/page/create_record">
+      <label for="complex-name">
+        Name <span>*</span>
+      </label>
+      <input id="complex-name" name="name" />
+
+      <label for="complex-human">
+        Human <span>*</span>
+      </label>
+      <input type="hidden" name="human" value="no" />
+      <input type="checkbox" id="complex-human" name="human" value="yes" />
+
+      <fieldset>
+        <legend>Book or movie?</legend>
+
+        <input type="radio" id="complex-book" name="book-or-movie" value="book" />
+        <label for="complex-book">Book <span>*</span></label>
+
+        <input type="radio" id="complex-movie" name="book-or-movie" value="movie" />
+        <label for="complex-movie">Movie <span>*</span></label>
+      </fieldset>
+
+      <label for="complex-animals">Choose a pet: <span>*</span></label>
+      <select id="complex-animals" name="pet">
+        <option value="dog">Dog</option>
+        <option value="cat">Cat</option>
+      </select>
+
+      <label for="complex-avatar">Avatar <span>*</span></label>
+      <input id="complex-avatar" name="avatar" type="file" />
+
+      <button type="submit">Save</button>
+    </form>
+
+    <form id="same-labels" action="/page/create_record" method="post">
       <fieldset>
         <legend>Do you like Elixir:</legend>
 


### PR DESCRIPTION
Closes #107, #127

What changed?
============

We update all form helpers (e.g. `fill_in`, `check`, etc.) to take in the `exact` option. The option allows forms to target labels exactly (default) or inexactly.

That's helpful when you have labels that have more complex contents -- for example, they might have nested HTML.