### PR TITLE
Set elixir 1.17 and erlang 27 in `.tool-versions`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         otp: ['26.1.2']
-        elixir: ['1.15.0', '1.16.0']
+        elixir: ['1.15.0', '1.16.0', '1.17.0']
     steps:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 26.1.2
-elixir 1.16.0-otp-26
+erlang 27.0
+elixir 1.17.2-otp-27


### PR DESCRIPTION
We also add elixir 1.17 to the CI matrix, but we keep otp 26 since only elixir 1.17 works with otp 27.