### PR TITLE
Copy headers across redirects

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -214,17 +214,27 @@ defmodule PhoenixTest do
   you're visiting.
   """
   def visit(conn, path) do
-    case get(conn, path) do
+    conn
+    |> recycle(all_headers(conn))
+    |> get(path)
+    |> case do
       %{assigns: %{live_module: _}} = conn ->
         PhoenixTest.Live.build(conn)
 
       %{status: 302} = conn ->
         path = redirected_to(conn)
-        visit(conn, path)
+
+        conn
+        |> recycle(all_headers(conn))
+        |> visit(path)
 
       conn ->
         PhoenixTest.Static.build(conn)
     end
+  end
+
+  defp all_headers(conn) do
+    Enum.map(conn.req_headers, &elem(&1, 0))
   end
 
   @doc """

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -239,9 +239,16 @@ defmodule PhoenixTest.Static do
   end
 
   defp perform_submit(session, form, form_data) do
-    session.conn
+    conn = session.conn
+
+    conn
+    |> recycle(all_headers(conn))
     |> dispatch(@endpoint, form.method, form.action, form_data)
     |> maybe_redirect(session)
+  end
+
+  defp all_headers(conn) do
+    Enum.map(conn.req_headers, &elem(&1, 0))
   end
 
   defp update_active_form(session, form, form_data) do


### PR DESCRIPTION
Resolves #126 

What changed?
============

In order to emulate browser behavior a little bit better, we want to copy headers across redirects.

Whenever we dispatch to the endpoint, the `Phoenix.ConnTest.recycle/2` automatically gets called. But by default it only recycles "accept", "accept-language", and "authorization".

This commit calls it manually copying _all_ request headers.

For more, see docs on
https://hexdocs.pm/phoenix/Phoenix.ConnTest.html#recycle/2

> Recycling receives a connection and returns a new connection,
containing cookies and relevant information from the given one.

> This emulates behaviour performed by browsers where cookies returned
in the response are available in following requests.

> By default, only the headers "accept", "accept-language", and
"authorization" are recycled. However, a custom set of headers can be specified by passing a list of strings representing its names as the second argument of the function.

> Note recycle/1 is automatically invoked when dispatching to the
endpoint, unless the connection has already been recycled.

## Need to check the following: 

- [x] Redirect on visit
- [x] Redirect when following links
- [x] Redirect when following form submissions