### PR TITLE
🛠️ Fix active form vs form data loading

### DIFF
--- a/lib/phoenix_test/active_form.ex
+++ b/lib/phoenix_test/active_form.ex
@@ -1,17 +1,15 @@
 defmodule PhoenixTest.ActiveForm do
   @moduledoc false
 
-  alias PhoenixTest.Form
-
   defstruct [:id, :selector, form_data: [], uploads: []]
 
-  def new(form_or_opts \\ [])
+  @doc """
+  Data structure for tracking active form fields filled.
 
-  def new(%Form{} = form) do
-    %__MODULE__{id: form.id, selector: form.selector, form_data: form.form_data}
-  end
-
-  def new(opts) when is_list(opts) do
+  Do not keep track of default form data on the page. That's what
+  `PhoenixTest.Form.form_data` is for.
+  """
+  def new(opts \\ []) when is_list(opts) do
     struct!(%__MODULE__{}, opts)
   end
 

--- a/test/phoenix_test/active_form_test.exs
+++ b/test/phoenix_test/active_form_test.exs
@@ -1,0 +1,16 @@
+defmodule PhoenixTest.ActiveFormTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixTest.ActiveForm
+
+  describe "add_form_data" do
+    test "adds form data passed" do
+      active_form =
+        [id: "user-form", selector: "#user-form"]
+        |> ActiveForm.new()
+        |> ActiveForm.add_form_data([{"user[name]", "Frodo"}])
+
+      assert active_form.form_data == [{"user[name]", "Frodo"}]
+    end
+  end
+end

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -369,40 +369,6 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "user:role: El Jefe")
     end
 
-    test "triggers phx-change validations", %{conn: conn} do
-      conn
-      |> visit("/live/index")
-      |> fill_in("Email", with: nil)
-      |> assert_has("#form-errors", text: "Errors present")
-    end
-
-    test "sends _target with phx-change events", %{conn: conn} do
-      conn
-      |> visit("/live/index")
-      |> fill_in("Email", with: "frodo@example.com")
-      |> assert_has("#form-data", text: "_target: [email]")
-    end
-
-    test "does not trigger phx-change event if one isn't present", %{conn: conn} do
-      session = visit(conn, "/live/index")
-
-      starting_html = Driver.render_html(session)
-
-      ending_html =
-        session
-        |> within("#no-phx-change-form", &fill_in(&1, "Name", with: "Aragorn"))
-        |> Driver.render_html()
-
-      assert starting_html == ending_html
-    end
-
-    test "follows redirects on phx-change", %{conn: conn} do
-      conn
-      |> visit("/live/index")
-      |> fill_in("Email with redirect", with: "someone@example.com")
-      |> assert_has("h1", text: "LiveView page 2")
-    end
-
     test "can be used to submit form", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -1030,6 +996,55 @@ defmodule PhoenixTest.LiveTest do
         |> click_button("Button with push patch")
 
       assert PhoenixTest.Driver.current_path(session) == "/live/index?foo=bar"
+    end
+  end
+
+  describe "shared form helpers behavior" do
+    test "triggers phx-change validations", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_in("Email", with: nil)
+      |> assert_has("#form-errors", text: "Errors present")
+    end
+
+    test "sends _target with phx-change events", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_in("Email", with: "frodo@example.com")
+      |> assert_has("#form-data", text: "_target: [email]")
+    end
+
+    test "does not trigger phx-change event if one isn't present", %{conn: conn} do
+      session = visit(conn, "/live/index")
+
+      starting_html = Driver.render_html(session)
+
+      ending_html =
+        session
+        |> within("#no-phx-change-form", &fill_in(&1, "Name", with: "Aragorn"))
+        |> Driver.render_html()
+
+      assert starting_html == ending_html
+    end
+
+    test "follows redirects on phx-change", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_in("Email with redirect", with: "someone@example.com")
+      |> assert_has("h1", text: "LiveView page 2")
+    end
+
+    test "preserves correct order of active form vs form data", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#changes-hidden-input-form", fn session ->
+        session
+        |> fill_in("Name", with: "Frodo")
+        |> fill_in("Email", with: "frodo@example.com")
+      end)
+      |> assert_has("#form-data", text: "name: Frodo")
+      |> assert_has("#form-data", text: "email: frodo@example.com")
+      |> assert_has("#form-data", text: "hidden_race: hobbit")
     end
   end
 end

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -376,6 +376,13 @@ defmodule PhoenixTest.IndexLive do
       </button>
     </form>
 
+    <form id="changes-hidden-input-form" phx-change="set-hidden-race">
+      <input type="hidden" name="hidden_race" value={@hidden_input_race} />
+
+      <label>Email <input type="email" name="email" /></label>
+      <label>Name <input type="name" name="name" /></label>
+    </form>
+
     <div id="not-a-form">
       <fieldset>
         <legend>Select a maintenance drone:</legend>
@@ -452,6 +459,7 @@ defmodule PhoenixTest.IndexLive do
       |> assign(:form_data, %{})
       |> assign(:show_form_errors, false)
       |> assign(:cities, [])
+      |> assign(:hidden_input_race, "human")
       |> allow_upload(:avatar, accept: ~w(.jpg .jpeg))
       |> allow_upload(:main_avatar, accept: ~w(.jpg .jpeg))
       |> allow_upload(:backup_avatar, accept: ~w(.jpg .jpeg))
@@ -485,6 +493,22 @@ defmodule PhoenixTest.IndexLive do
       socket
       |> assign(:form_saved, true)
       |> assign(:form_data, form_data)
+    }
+  end
+
+  def handle_event("set-hidden-race", form_data, socket) do
+    race =
+      case form_data["name"] do
+        "Frodo" -> "hobbit"
+        _ -> "human"
+      end
+
+    {
+      :noreply,
+      socket
+      |> assign(:form_saved, true)
+      |> assign(:form_data, form_data)
+      |> assign(:hidden_input_race, race)
     }
   end
 


### PR DESCRIPTION
Resolves #105 

What changed?
=============

At some point, a page's default data (parsed in `Form`) would become part of the `ActiveForm` form data.

That meant that if the data on the page changed, the stuff that had been filled in on a previous form action would prevail because it was acting as part of the "active form" data.

This is the way this should work (done in this commit):

- `ActiveForm` should _ONLY_ keep track of fields that have been filled in. The rest of the data to submit should come from `form.form_data`. We should not copy it and keep track of it there.

- `click_button`, `submit`, and anything else that triggers changes (like `phx-change`) should know to combine `form.form_data ++ ActiveForm.form_data` before sending it to the server.

- We should probably keep track of form data in a map instead of a list of tuples. We used to keep it in a nested map, and we wanted to flatten it. We should still keep it flat, but we should make it a map. That's left for future work since it's not affecting the current fix.

Test notes
----------

We move common form helper behavior tests out of fill_in and into a shared tests group.