### PR TITLE
Deduplicate data passed to FormPayload

### DIFF
--- a/lib/phoenix_test/form_payload.ex
+++ b/lib/phoenix_test/form_payload.ex
@@ -3,10 +3,18 @@ defmodule PhoenixTest.FormPayload do
 
   def new(form_data) when is_list(form_data) do
     form_data
+    |> deduplicate_preserving_order()
     |> Enum.map_join("&", fn {key, value} ->
       "#{URI.encode_www_form(key)}=#{if(value, do: URI.encode_www_form(value))}"
     end)
     |> Plug.Conn.Query.decode()
+  end
+
+  defp deduplicate_preserving_order(form_data) do
+    form_data
+    |> Enum.reverse()
+    |> Enum.uniq()
+    |> Enum.reverse()
   end
 
   def add_form_data(payload, form_data) when is_map(payload) and is_list(form_data) do

--- a/test/phoenix_test/form_payload_test.exs
+++ b/test/phoenix_test/form_payload_test.exs
@@ -2,6 +2,7 @@ defmodule PhoenixTest.FormPayloadTest do
   use ExUnit.Case, async: true
 
   alias PhoenixTest.Form
+  alias PhoenixTest.FormData
   alias PhoenixTest.FormPayload
 
   describe "new" do
@@ -105,6 +106,29 @@ defmodule PhoenixTest.FormPayloadTest do
       form = Form.find!(html, "form")
 
       assert %{"hidden" => ["some_value"]} = FormPayload.new(form.form_data)
+    end
+
+    test "deduplicates data with same name with [] and same value" do
+      form_data =
+        "email[]"
+        |> FormData.to_form_data("value")
+        |> FormData.add_data(FormData.to_form_data("email[]", "value"))
+
+      payload = FormPayload.new(form_data)
+
+      assert payload == %{"email" => ["value"]}
+    end
+
+    test "preserves order of operations when deduplicating data" do
+      form_data =
+        "email"
+        |> FormData.to_form_data("value")
+        |> FormData.add_data(FormData.to_form_data("email", "other_value"))
+        |> FormData.add_data(FormData.to_form_data("email", "value"))
+
+      payload = FormPayload.new(form_data)
+
+      assert payload == %{"email" => "value"}
     end
 
     test "ignores hidden value for checkbox when checked" do


### PR DESCRIPTION
Closes #110 

What changed?
=============

Currently, `FormData` keeps the data passed as a list of tuples. That's not an optimal strategy since it doesn't deal with duplicates well.

That being said, there are two competing behaviors that we need to handle:

- One the one hand, we want to keep duplicates of list-like `name`s (e.g. `{"contact[]", "email"}`.
- On the other hand, we don't really want to keep duplicates of the same operation done multiple times (e.g. `[{"email", "frodo@example.com"}, {"email", "aragorn@example.com"}]`).

In the latter case, we can imagine a user doing a `fill_in` twice, where the email field changed twice. In the first case, we might have something like a checkbox where the user can check multiple values.

Like we said, a list of tuples doesn't seem to be the optimal data structure for `FormData`. But while we have it, we handle deduplication of keys in `FormPayload.new/1`.

But we have to consider one more case. If a user calls:

```elixir
session
|> fill_in("Email", with: "frodo@example.com")
|> fill_in("Email", with: "aragorn@example.com")
|> fill_in("Email", with: "frodo@example.com")
```

The final record should show `frodo@example.com` as the `email`. If we do a simple `Enum.uniq/1`, we dedup `frood@example.com`, leaving `aragorn@example.com` as the last operation -- which is not what we want. Thus, our current implementation has to reverse the list of data, unique it, and then reverse it again.