### PR TITLE
Fix: Latest HTML position trumps latest entry

### DIFF
--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -828,6 +828,15 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("h1", text: "Record deleted")
     end
 
+    test "submits input value with latest HTML position, not latest fill_in", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> fill_in("Email duplicate 2", with: "Latest HTML position")
+      |> fill_in("Email duplicate 1", with: "Latest fill_in")
+      |> submit()
+      |> assert_has("#form-data", text: "email: Latest HTML position")
+    end
+
     test "raises an error if there's no active form", %{conn: conn} do
       msg = ~r/There's no active form. Fill in a form with `fill_in`, `select`, etc./
 

--- a/test/support/page_view.ex
+++ b/test/support/page_view.ex
@@ -390,6 +390,12 @@ defmodule PhoenixTest.PageView do
 
       <input type="submit" name="button" value="Save form" />
     </form>
+
+    <form id="duplicate-inputs" action="/page/create_record" method="POST">
+      <label>Email duplicate 1<input id="email-duplicate-1" name="email" /></label>
+      <label>Email duplicate 2<input id="email-duplicate-2" name="email" /></label>
+      <button>Submit</button>
+    </form>
     """
   end
 


### PR DESCRIPTION
Looking at #137 I realised we probably have a bug (already prior to #137).

## Todo
- [x] Add failing test
- [ ] Fix

## Given
```html
<label>Email duplicate 1<input id="email-duplicate-1" name="email" /></label>
<label>Email duplicate 2<input id="email-duplicate-2" name="email" /></label>
```

```ex
|> fill_in("Email duplicate 2", with: "Latest HTML position")
|> fill_in("Email duplicate 1", with: "Latest fill_in")
```

## Expected
```ex
# POST email=Latest fill_in&email=Latest HTML position
params = %{"email" => "Latest HTML position"}
```

## Actual
```ex
params = %{"email" => "Latest fill_in"}
```

## Background
> list of all the submittable elements whose form owner is form, in [tree order](https://www.w3.org/TR/2011/WD-html5-20110525/infrastructure.html#tree-order)
https://www.w3.org/TR/2011/WD-html5-20110525/association-of-controls-and-forms.html#constructing-form-data-set