### PR TITLE
Update `phx_click?` to check for valid JS commands

### DIFF
--- a/lib/phoenix_test/button.ex
+++ b/lib/phoenix_test/button.ex
@@ -4,6 +4,7 @@ defmodule PhoenixTest.Button do
   alias PhoenixTest.Element
   alias PhoenixTest.Form
   alias PhoenixTest.Html
+  alias PhoenixTest.LiveViewBindings
   alias PhoenixTest.Query
   alias PhoenixTest.Utils
 
@@ -58,11 +59,7 @@ defmodule PhoenixTest.Button do
     end
   end
 
-  def phx_click?(button) do
-    button.parsed
-    |> Html.attribute("phx-click")
-    |> Utils.present?()
-  end
+  def phx_click?(button), do: LiveViewBindings.phx_click?(button.parsed)
 
   def has_data_method?(button) do
     button.parsed

--- a/lib/phoenix_test/field.ex
+++ b/lib/phoenix_test/field.ex
@@ -4,8 +4,8 @@ defmodule PhoenixTest.Field do
   alias PhoenixTest.Element
   alias PhoenixTest.Form
   alias PhoenixTest.Html
+  alias PhoenixTest.LiveViewBindings
   alias PhoenixTest.Query
-  alias PhoenixTest.Utils
 
   @enforce_keys ~w[source_raw parsed label id name value selector]a
   defstruct ~w[source_raw parsed label id name value selector]a
@@ -68,11 +68,7 @@ defmodule PhoenixTest.Field do
     Form.find_by_descendant!(field.source_raw, field)
   end
 
-  def phx_click?(field) do
-    field.parsed
-    |> Html.attribute("phx-click")
-    |> Utils.present?()
-  end
+  def phx_click?(field), do: LiveViewBindings.phx_click?(field.parsed)
 
   def belongs_to_form?(field) do
     case Query.find_ancestor(field.source_raw, "form", field.selector) do

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -82,7 +82,7 @@ defmodule PhoenixTest.Live do
 
       true ->
         raise ArgumentError, """
-        Expected element with selector #{inspect(selector)} and text #{inspect(text)} to have a `phx-click` attribute or belong to a `form` element.
+        Expected element with selector #{inspect(selector)} and text #{inspect(text)} to have a valid `phx-click` attribute or belong to a `form` element.
         """
     end
   end
@@ -126,7 +126,7 @@ defmodule PhoenixTest.Live do
 
       true ->
         raise ArgumentError, """
-        Expected select with selector #{inspect(field.selector)} to have a `phx-click` attribute on options or to belong to a `form` element.
+        Expected select with selector #{inspect(field.selector)} to have a valid `phx-click` attribute on options or to belong to a `form` element.
         """
     end
   end
@@ -149,7 +149,7 @@ defmodule PhoenixTest.Live do
 
       true ->
         raise ArgumentError, """
-        Expected checkbox with selector #{inspect(field.selector)} to have a `phx-click` attribute or belong to a `form` element.
+        Expected checkbox with selector #{inspect(field.selector)} to have a valid `phx-click` attribute or belong to a `form` element.
         """
     end
   end
@@ -173,7 +173,7 @@ defmodule PhoenixTest.Live do
 
       true ->
         raise ArgumentError, """
-        Expected checkbox with selector #{inspect(field.selector)} to have a `phx-click` attribute or belong to a `form` element.
+        Expected checkbox with selector #{inspect(field.selector)} to have a valid `phx-click` attribute or belong to a `form` element.
         """
     end
   end
@@ -196,7 +196,7 @@ defmodule PhoenixTest.Live do
 
       true ->
         raise ArgumentError, """
-        Expected radio input with selector #{inspect(field.selector)} to have a `phx-click` attribute or belong to a `form` element.
+        Expected radio input with selector #{inspect(field.selector)} to have a valid `phx-click` attribute or belong to a `form` element.
         """
     end
   end

--- a/lib/phoenix_test/live_view_bindings.ex
+++ b/lib/phoenix_test/live_view_bindings.ex
@@ -1,0 +1,20 @@
+defmodule PhoenixTest.LiveViewBindings do
+  @moduledoc false
+
+  alias PhoenixTest.Html
+  alias PhoenixTest.Utils
+
+  def phx_click?(parsed_element) do
+    parsed_element
+    |> Html.attribute("phx-click")
+    |> valid_event_or_js_command?()
+  end
+
+  defp valid_event_or_js_command?("[" <> _ = js_command), do: valid_js_command?(js_command)
+  defp valid_event_or_js_command?(value), do: Utils.present?(value)
+
+  @commands_live_view_test_handles ~w[push navigate]
+  defp valid_js_command?(js_command) do
+    String.contains?(js_command, @commands_live_view_test_handles)
+  end
+end

--- a/lib/phoenix_test/select.ex
+++ b/lib/phoenix_test/select.ex
@@ -3,8 +3,8 @@ defmodule PhoenixTest.Select do
 
   alias PhoenixTest.Element
   alias PhoenixTest.Html
+  alias PhoenixTest.LiveViewBindings
   alias PhoenixTest.Query
-  alias PhoenixTest.Utils
 
   @enforce_keys ~w[source_raw selected_options parsed label id name value selector]a
   defstruct ~w[source_raw selected_options parsed label id name value selector]a
@@ -58,11 +58,7 @@ defmodule PhoenixTest.Select do
   end
 
   def phx_click_options?(field) do
-    Enum.all?(field.selected_options, fn option ->
-      option
-      |> Html.attribute("phx-click")
-      |> Utils.present?()
-    end)
+    Enum.all?(field.selected_options, &LiveViewBindings.phx_click?/1)
   end
 
   def select_option_selector(field, value) do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -259,7 +259,7 @@ defmodule PhoenixTest.LiveTest do
     end
 
     test "raises an error if button is not part of form and has no phx-submit", %{conn: conn} do
-      msg = ~r/to have a `phx-click` attribute or belong to a `form` element/
+      msg = ~r/to have a valid `phx-click` attribute or belong to a `form` element/
 
       assert_raise ArgumentError, msg, fn ->
         conn
@@ -515,7 +515,7 @@ defmodule PhoenixTest.LiveTest do
     test "raises an error if select option is neither in a form nor has a phx-click", %{conn: conn} do
       session = visit(conn, "/live/index")
 
-      assert_raise ArgumentError, ~r/to have a `phx-click` attribute on options or to belong to a `form`/, fn ->
+      assert_raise ArgumentError, ~r/to have a valid `phx-click` attribute on options or to belong to a `form`/, fn ->
         select(session, "Dog", from: "Invalid Select Option")
       end
     end
@@ -585,7 +585,7 @@ defmodule PhoenixTest.LiveTest do
     test "raises error if checkbox doesn't have phx-click or belong to form", %{conn: conn} do
       session = visit(conn, "/live/index")
 
-      assert_raise ArgumentError, ~r/have a `phx-click` attribute or belong to a `form`/, fn ->
+      assert_raise ArgumentError, ~r/have a valid `phx-click` attribute or belong to a `form`/, fn ->
         check(session, "Invalid Checkbox")
       end
     end
@@ -655,7 +655,7 @@ defmodule PhoenixTest.LiveTest do
     test "raises error if checkbox doesn't have phx-click or belong to form", %{conn: conn} do
       session = visit(conn, "/live/index")
 
-      assert_raise ArgumentError, ~r/have a `phx-click` attribute or belong to a `form`/, fn ->
+      assert_raise ArgumentError, ~r/have a valid `phx-click` attribute or belong to a `form`/, fn ->
         uncheck(session, "Invalid Checkbox")
       end
     end
@@ -707,7 +707,7 @@ defmodule PhoenixTest.LiveTest do
     test "raises an error if radio is neither in a form nor has a phx-click", %{conn: conn} do
       session = visit(conn, "/live/index")
 
-      assert_raise ArgumentError, ~r/to have a `phx-click` attribute or belong to a `form` element/, fn ->
+      assert_raise ArgumentError, ~r/to have a valid `phx-click` attribute or belong to a `form` element/, fn ->
         choose(session, "Invalid Radio Button")
       end
     end

--- a/test/phoenix_test/live_view_bindings_test.exs
+++ b/test/phoenix_test/live_view_bindings_test.exs
@@ -1,0 +1,89 @@
+defmodule PhoenixTest.LiveViewBindingsTest do
+  use ExUnit.Case, async: true
+
+  import Phoenix.Component
+  import Phoenix.LiveViewTest
+
+  alias Phoenix.LiveView.JS
+  alias PhoenixTest.LiveViewBindings
+
+  describe "phx_click?" do
+    test "returns true if parsed element has a phx-click handler" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <input phx-click="save" />
+        """)
+
+      [element] = Floki.find(html, "input")
+
+      assert LiveViewBindings.phx_click?(element)
+    end
+
+    test "returns false if field doesn't have a phx-click handler" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <input value="Hello world" />
+        """)
+
+      [element] = Floki.find(html, "input")
+
+      refute LiveViewBindings.phx_click?(element)
+    end
+
+    test "returns true if JS command is a push (LiveViewTest can handle)" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <input phx-click={JS.push("save")} />
+        """)
+
+      [element] = Floki.find(html, "input")
+
+      assert LiveViewBindings.phx_click?(element)
+    end
+
+    test "returns true if JS command is a navigate (LiveViewTest can handle)" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <input phx-click={JS.navigate("save")} />
+        """)
+
+      [element] = Floki.find(html, "input")
+
+      assert LiveViewBindings.phx_click?(element)
+    end
+
+    test "returns false if JS command is a dispatch" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <input phx-click={JS.dispatch("change")} />
+        """)
+
+      [element] = Floki.find(html, "input")
+
+      refute LiveViewBindings.phx_click?(element)
+    end
+
+    test "returns true if JS commands include a push or navigate" do
+      assigns = %{}
+
+      html =
+        rendered_to_string(~H"""
+        <input phx-click={JS.push("save") |> JS.dispatch("change")} />
+        """)
+
+      [element] = Floki.find(html, "input")
+
+      assert LiveViewBindings.phx_click?(element)
+    end
+  end
+end


### PR DESCRIPTION
Closes #122 

What changed?
============

Unless `phx-click` has a valid JS command, we don't really want to handle it as part of the `Field.phx_click?`, `Button.phx_click?`, or `Select.phx_click?` actions.

So, in this commit, we parse the `phx-click` attribute. When it's a JS command, we check to see if the value is `push` or `navigate`.

Why do we do this? Why not let LiveViewTest handle it? 
------------------------------------------------------

LiveViewTest already throws an error when a `phx-click` has a JS command that doesn't include a `push` or `navigate`. So, why do this?

Because PhoenixTest automatically handles `phx-clicks`.

When an element is inside a form AND it has a `phx-click` that doesn't have a `push` or `navigate` (e.g. `JS.dispatch/1`), we need to ignore the element. We don't want to raise because it's technically valid code.

Something to note: PhoenixTest doesn't currently handle a form element AND a valid `phx-click` event at the same time. That is, if a form has a `phx-change` attribute and a checkbox has a `phx-click` attribute with an event or a `JS.push`, only one of those events (the `phx-change` OR the `phx-click`) will make it to the server. In production LiveView, both events get sent. So, that's something we want to handle, but it is not covered in this commit.