### PR TITLE
Fix: Raise error if implicit + explicit label found

### DIFF
--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -272,9 +272,16 @@ defmodule PhoenixTest.Query do
       {:explicit_association, label_element} ->
         find_label_input(html, input_selectors, label_element)
 
-      {:found_many, label_elements} ->
-        label_elements
-        |> Enum.map(&find_label_input(html, input_selectors, &1))
+      {:found_many, associations} ->
+        maybe_label_elements =
+          Enum.map(associations, fn
+            {:implicit_association, _label_element, element} -> {:found, element}
+            {:explicit_association, label_element} -> find_label_input(html, input_selectors, label_element)
+          end)
+
+        label_elements = for {:found, e} <- maybe_label_elements, do: e
+
+        maybe_label_elements
         |> Enum.filter(fn
           {:found, _} -> true
           _ -> false
@@ -301,7 +308,7 @@ defmodule PhoenixTest.Query do
         determine_implicit_or_explicit_label(element, input_selectors)
 
       {:found_many, elements} ->
-        {:found_many, elements}
+        {:found_many, Enum.map(elements, &determine_implicit_or_explicit_label(&1, input_selectors))}
     end
   end
 

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -1040,8 +1040,8 @@ defmodule PhoenixTest.LiveTest do
       |> visit("/live/index")
       |> within("#changes-hidden-input-form", fn session ->
         session
-        |> fill_in("Name", with: "Frodo")
-        |> fill_in("Email", with: "frodo@example.com")
+        |> fill_in("Name for hidden", with: "Frodo")
+        |> fill_in("Email for hidden", with: "frodo@example.com")
       end)
       |> assert_has("#form-data", text: "name: Frodo")
       |> assert_has("#form-data", text: "email: frodo@example.com")

--- a/test/phoenix_test/query_test.exs
+++ b/test/phoenix_test/query_test.exs
@@ -453,6 +453,19 @@ defmodule PhoenixTest.QueryTest do
       end
     end
 
+    test "raises error if label has for attribute and nested input" do
+      html = """
+      <label for="other_greeting">Hello <input /></label>
+      <input id="other_greeting" />
+      """
+
+      msg = ~r/Found a label which references two different inputs/
+
+      assert_raise ArgumentError, msg, fn ->
+        Query.find_by_label!(html, "input", "Hello")
+      end
+    end
+
     test "returns found element" do
       html = """
       <label for="greeting">Hello</label>

--- a/test/phoenix_test/query_test.exs
+++ b/test/phoenix_test/query_test.exs
@@ -438,6 +438,21 @@ defmodule PhoenixTest.QueryTest do
       end
     end
 
+    test "raises error if multiple labels and inputs match (one explicit, one implicit)" do
+      html = """
+      <label for="greeting">Hello</label>
+      <input id="greeting" />
+
+      <label>Hello <input id="second_greeting" /></label>
+      """
+
+      msg = ~r/Found many elements with label "Hello" and matching the provided selectors/
+
+      assert_raise ArgumentError, msg, fn ->
+        Query.find_by_label!(html, "input", "Hello")
+      end
+    end
+
     test "returns found element" do
       html = """
       <label for="greeting">Hello</label>

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -382,8 +382,8 @@ defmodule PhoenixTest.IndexLive do
     <form id="changes-hidden-input-form" phx-change="set-hidden-race">
       <input type="hidden" name="hidden_race" value={@hidden_input_race} />
 
-      <label>Email <input type="email" name="email" /></label>
-      <label>Name <input type="name" name="name" /></label>
+      <label>Email for hidden <input type="email" name="email" /></label>
+      <label>Name for hidden <input type="name" name="name" /></label>
     </form>
 
     <div id="not-a-form">


### PR DESCRIPTION
Found via #136 

## Given
```html
<label for="greeting">Hello</label>
<input id="greeting" />

<label>Hello <input id="second_greeting" /></label>
```

```ex
session
|> fill_in("Hello", with: "world")
```

## Expected
```ex
ArgumentError: Found many elements with label "Hello" and matching the provided selectors
```

## Actual
No error. Label with explicit `for` wins, other one ignored.