### PR TITLE
Live redirect copy headers

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -328,9 +328,10 @@ defmodule PhoenixTest.Live do
 
   defp maybe_redirect({:error, {:live_redirect, %{to: path}}} = result, session) do
     session = %{session | current_path: path}
+    conn = session.conn
 
     result
-    |> follow_redirect(session.conn)
+    |> follow_redirect(recycle(conn, all_headers(conn)))
     |> maybe_redirect(session)
   end
 

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -223,6 +223,17 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("h1", text: "LiveView page 2")
     end
 
+    test "follows form's redirect and preserves headers", %{conn: conn} do
+      conn
+      |> Plug.Conn.put_req_header("x-auth-header", "Some-Value")
+      |> visit("/auth/live/index")
+      |> within("#live-redirect-form", &select(&1, "Two", from: "Name"))
+      |> assert_path("/auth/live/page_2")
+      |> then(fn %{conn: conn} ->
+        assert {"x-auth-header", "Some-Value"} in conn.req_headers
+      end)
+    end
+
     test "follows form's redirect to static page", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -198,6 +198,14 @@ defmodule PhoenixTest.IndexLive do
       </button>
     </form>
 
+    <form id="live-redirect-form" phx-change="change-redirect-form">
+      <label for="live-redirect-form-name">Name</label>
+      <select id="live-redirect-form-name" name="name">
+        <option value="1">One</option>
+        <option value="2">Two</option>
+      </select>
+    </form>
+
     <form id="redirect-form-to-static" phx-submit="save-redirect-form-to-static">
       <label for="redirect-to-static-name">Name</label>
       <input id="redirect-to-static-name" name="name" />
@@ -590,6 +598,10 @@ defmodule PhoenixTest.IndexLive do
 
   def handle_event("save-redirect-form", _, socket) do
     {:noreply, push_navigate(socket, to: "/live/page_2")}
+  end
+
+  def handle_event("change-redirect-form", _, socket) do
+    {:noreply, push_navigate(socket, to: "/auth/live/page_2")}
   end
 
   def handle_event("save-redirect-form-to-static", _, socket) do

--- a/test/support/router.ex
+++ b/test/support/router.ex
@@ -37,7 +37,21 @@ defmodule PhoenixTest.Router do
       live "/live/page_2", Page2Live
     end
 
+    scope "/auth" do
+      pipe_through([:proxy_header_auth])
+
+      live "/live/index", IndexLive
+      live "/live/page_2", Page2Live
+    end
+
     live "/live/index_no_layout", IndexLive
     live "/live/redirect_on_mount/:redirect_type", RedirectLive
+  end
+
+  def proxy_header_auth(conn, _opts) do
+    case get_req_header(conn, "x-auth-header") do
+      [value] -> put_session(conn, :auth_header, value)
+      _ -> conn |> send_resp(401, "Unauthorized") |> halt()
+    end
   end
 end


### PR DESCRIPTION
The added behavior of copying headers wasn't working in my application, and after toying around with a local path dependency, I found that in the `:live_redirect` case the headers weren't being copied. While adding the call to `recycle/2` with the list of all headers made things work again, I wasn't sure why all of your tests were passing.

Included in this PR is a scenario the more closely mirrors what is happening in my application, where the cookie session is modified in a Plug. This scenario provokes the error, and my second commit adds the additional header copy to pass the tests. I suspect the test case could be integrated into the test suite better.