### PR TITLE
Support visit/2 for custom drivers

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -213,7 +213,7 @@ defmodule PhoenixTest do
   LiveView or a static view. You don't need to worry about which type of page
   you're visiting.
   """
-  def visit(conn, path) do
+  def visit(%Plug.Conn{} = conn, path) do
     case get(conn, path) do
       %{assigns: %{live_module: _}} = conn ->
         PhoenixTest.Live.build(conn)
@@ -228,6 +228,10 @@ defmodule PhoenixTest do
       conn ->
         PhoenixTest.Static.build(conn)
     end
+  end
+
+  def visit(driver, path) when is_struct(driver) do
+    Driver.visit(driver, path)
   end
 
   defp all_headers(conn) do

--- a/lib/phoenix_test/driver.ex
+++ b/lib/phoenix_test/driver.ex
@@ -1,5 +1,6 @@
 defprotocol PhoenixTest.Driver do
   @moduledoc false
+  def visit(session, path)
   def render_page_title(session)
   def render_html(session)
   def click_link(session, selector, text)

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -367,6 +367,7 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   alias PhoenixTest.Assertions
   alias PhoenixTest.Live
 
+  def visit(_, _), do: raise(ArgumentError, message: "Unexpected: Call visit/1 with a %Plug.Conn{}.")
   defdelegate render_page_title(session), to: Live
   defdelegate render_html(session), to: Live
   defdelegate click_link(session, selector, text), to: Live

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -292,6 +292,7 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
   alias PhoenixTest.Assertions
   alias PhoenixTest.Static
 
+  def visit(_, _), do: raise(ArgumentError, message: "Unexpected: Call visit/1 with a %Plug.Conn{}.")
   defdelegate render_page_title(session), to: Static
   defdelegate render_html(session), to: Static
   defdelegate click_link(session, selector, text), to: Static


### PR DESCRIPTION
In addition to the auto detection of `Live` vs. `Static` via `Plug.Conn`.

Usage (add a test?):

```ex
setup_args
|> MyDriver.build()
|> visit("/path")
...
```

## Alternative (that wouldn't require changes to PhoenixTest)

Instead of adding a `visit/2` to the Driver protocol, custom drivers could implement their own variant.
No real downside. Apart from making it more or less obvious that custom drivers are supported. 

```ex
setup_args
|> MyDriver.visit("/path")
...
```