### PR TITLE
Normalize whitespace (find label with line breaks)

### DIFF
--- a/lib/phoenix_test/html.ex
+++ b/lib/phoenix_test/html.ex
@@ -5,7 +5,9 @@ defmodule PhoenixTest.Html do
     Floki.parse_document!(html)
   end
 
-  def text(element), do: element |> Floki.text() |> String.trim()
+  def text(element) do
+    element |> Floki.text() |> String.trim() |> normalize_whitespace()
+  end
 
   def attribute(element, attr) do
     element
@@ -18,4 +20,8 @@ defmodule PhoenixTest.Html do
   end
 
   def raw(html_string), do: Floki.raw_html(html_string, pretty: true)
+
+  defp normalize_whitespace(string) do
+    String.replace(string, ~r/[\s]+/, " ")
+  end
 end

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -584,6 +584,15 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "human: yes")
     end
 
+    test "can target a label with line breaks (ingoring extra whitespace)", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#complex-labels", fn session ->
+        check(session, "With line breaks")
+      end)
+      |> assert_has("#form-data", text: "with_linebreaks: yes")
+    end
+
     test "can specify input selector when multiple checkboxes have same label", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -272,6 +272,12 @@ defmodule PhoenixTest.IndexLive do
       </label>
       <input id="complex-name" name="name" />
 
+      <label phx-no-format>
+        With
+        <em>line breaks</em>
+        <input type="checkbox" name="with_linebreaks" value="yes" />
+      </label>
+
       <label for="complex-human">
         Human <span>*</span>
       </label>


### PR DESCRIPTION
Similar to other feature testing libraries.

Wallaby
>  Matches any element by its inner text.
`~s{.//*[contains(normalize-space(text()), "#{selector}")]}`
[xpath.ex](https://github.com/elixir-wallaby/wallaby/blob/c144c92e8bc1812c1f712cc1f1c652c4d2c7ce4b/lib/wallaby/query/xpath.ex#L80)
https://developer.mozilla.org/en-US/docs/Web/XPath/Functions/normalize-space

Playwright
> Matching by text always normalizes whitespace, even with exact match. For example, it turns multiple spaces into one, turns line breaks into spaces and ignores leading and trailing whitespace.
https://playwright.dev/docs/locators#get-by-text