### PR TITLE
Fix: Don't fail for disabled select

### DIFF
--- a/lib/phoenix_test/element/form.ex
+++ b/lib/phoenix_test/element/form.ex
@@ -103,7 +103,7 @@ defmodule PhoenixTest.Element.Form do
 
   defp form_data_select(form) do
     form
-    |> Html.all("select")
+    |> Html.all("select:not([disabled])")
     |> Enum.flat_map(fn select ->
       multiple = !is_nil(Html.attribute(select, "multiple"))
 

--- a/test/support/index_live.ex
+++ b/test/support/index_live.ex
@@ -184,6 +184,13 @@ defmodule PhoenixTest.IndexLive do
       Prefilled content
       </textarea>
 
+      <label>
+        Disabled select
+        <select disabled name="disabled_select">
+          <option value="">Select...</option>
+        </select>
+      </label>
+
       <label for={@uploads.avatar.ref}>Avatar</label>
       <.live_file_input upload={@uploads.avatar} />
 


### PR DESCRIPTION
A disabled select currently causes all input functions to fail.

Example:

```
     ** (ArgumentError) could not find non-disabled input, select or textarea with name "disabled_select" within:
...
       (phoenix_live_view 1.0.0) lib/phoenix_live_view/test/live_view_test.ex:1106: Phoenix.LiveViewTest.call/2
       (phoenix_test 0.4.2) lib/phoenix_test/live.ex:296: PhoenixTest.Live.submit_form/4
       test/phoenix_test/live_test.exs:359: (test)
```

Fix: Ignore disabled selects when building initial form data, just as we ignore all other disabled input types.