### PR TITLE
Add `visit/2` to Driver protocol

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -194,14 +194,13 @@ defmodule PhoenixTest do
   For more info, see `within/3`.
   """
 
-  import Phoenix.ConnTest
   import PhoenixTest.Locators
 
+  alias PhoenixTest.ConnHandler
   alias PhoenixTest.Driver
   alias PhoenixTest.Element.Button
   alias PhoenixTest.Query
 
-  @endpoint Application.compile_env(:phoenix_test, :endpoint)
   @doc """
   Entrypoint to create a session.
 
@@ -213,25 +212,12 @@ defmodule PhoenixTest do
   LiveView or a static view. You don't need to worry about which type of page
   you're visiting.
   """
-  def visit(conn, path) do
-    case get(conn, path) do
-      %{assigns: %{live_module: _}} = conn ->
-        PhoenixTest.Live.build(conn)
-
-      %{status: 302} = conn ->
-        path = redirected_to(conn)
-
-        conn
-        |> recycle(all_headers(conn))
-        |> visit(path)
-
-      conn ->
-        PhoenixTest.Static.build(conn)
-    end
+  def visit(%Plug.Conn{} = conn, path) do
+    ConnHandler.visit(conn, path)
   end
 
-  defp all_headers(conn) do
-    Enum.map(conn.req_headers, &elem(&1, 0))
+  def visit(initial_struct, path) do
+    Driver.visit(initial_struct, path)
   end
 
   @doc """

--- a/lib/phoenix_test/conn_handler.ex
+++ b/lib/phoenix_test/conn_handler.ex
@@ -1,0 +1,27 @@
+defmodule PhoenixTest.ConnHandler do
+  @moduledoc false
+  import Phoenix.ConnTest
+
+  @endpoint Application.compile_env(:phoenix_test, :endpoint)
+
+  def visit(conn, path) do
+    case get(conn, path) do
+      %{assigns: %{live_module: _}} = conn ->
+        PhoenixTest.Live.build(conn)
+
+      %{status: 302} = conn ->
+        path = redirected_to(conn)
+
+        conn
+        |> recycle(all_headers(conn))
+        |> visit(path)
+
+      conn ->
+        PhoenixTest.Static.build(conn)
+    end
+  end
+
+  defp all_headers(conn) do
+    Enum.map(conn.req_headers, &elem(&1, 0))
+  end
+end

--- a/lib/phoenix_test/driver.ex
+++ b/lib/phoenix_test/driver.ex
@@ -1,5 +1,6 @@
 defprotocol PhoenixTest.Driver do
   @moduledoc false
+  def visit(initial_struct, path)
   def render_page_title(session)
   def render_html(session)
   def click_link(session, selector, text)

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -381,8 +381,10 @@ end
 
 defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   alias PhoenixTest.Assertions
+  alias PhoenixTest.ConnHandler
   alias PhoenixTest.Live
 
+  defdelegate visit(conn, path), to: ConnHandler
   defdelegate render_page_title(session), to: Live
   defdelegate render_html(session), to: Live
   defdelegate click_link(session, selector, text), to: Live

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -290,8 +290,10 @@ end
 
 defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
   alias PhoenixTest.Assertions
+  alias PhoenixTest.ConnHandler
   alias PhoenixTest.Static
 
+  defdelegate visit(conn, path), to: ConnHandler
   defdelegate render_page_title(session), to: Static
   defdelegate render_html(session), to: Static
   defdelegate click_link(session, selector, text), to: Static


### PR DESCRIPTION
Supersedes #149 

In order to support external libraries implementing the `Driver` protocol, we move the `visit/2` call out of `PhoenixTest`. When it's a `Plug.Conn` struct, we delegate to `ConnHandler.visit/2` (not the best name, but good enough for now).