### PR TITLE
Use Elixir 1.18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         otp: ['26.1.2']
-        elixir: ['1.15.0', '1.16.0', '1.17.0']
+        elixir: ['1.15.0', '1.16.0', '1.17.0', '1.18.0']
     steps:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 erlang 27.0
-elixir 1.17.2-otp-27
+elixir 1.18.1-otp-27


### PR DESCRIPTION
We update the `.tool-versions` file to use Elixir 1.18, and update
the CI matrix to use OTP 27 and include Elixir 1.18.

We could probably drop Elixir 1.15, but we don't do it if we don't need
to yet.
