### PR TITLE
feat: :sparkles: trigger phx-change on upload

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1095,9 +1095,12 @@ defmodule PhoenixTest do
   @doc """
   Upload a file.
 
-  If the form is a LiveView form, this will perform a live file upload.
+  If the form is a LiveView form, this will perform a live file upload and trigger the associated `phx-change` event.
 
   This can be followed by a `click_button/3` or `submit/1` to submit the form.
+
+  > LiveView Note: If `allow_upload/3` has a `:progress` callback that issues a navigate or redirect,
+  > it will be used instead of any navigate, redirect or patch from the upload's `phx-change` event.
 
   ## Options
 

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -259,11 +259,24 @@ defmodule PhoenixTest.Live do
       type: mime_type
     }
 
+    upload_progress_result =
+      session.view
+      |> file_input(form.selector, live_upload_name, [entry])
+      |> render_upload(file_name)
+      |> maybe_throw_upload_errors(session, file_name, live_upload_name)
+
     session.view
-    |> file_input(form.selector, live_upload_name, [entry])
-    |> render_upload(file_name)
-    |> maybe_throw_upload_errors(session, file_name, live_upload_name)
-    |> maybe_redirect(session)
+    |> form(form.selector)
+    |> render_change(%{"_target" => field.name})
+    |> progress_redirect_or_change_result(upload_progress_result, session)
+  end
+
+  defp progress_redirect_or_change_result(_change_result, {:error, _} = upload_progress_result, session) do
+    maybe_redirect(upload_progress_result, session)
+  end
+
+  defp progress_redirect_or_change_result(change_result, _upload_progress_result, session) do
+    maybe_redirect(change_result, session)
   end
 
   defp maybe_throw_upload_errors({:error, [[_id, error]]}, session, file_name, live_upload_name) do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -790,6 +790,24 @@ defmodule PhoenixTest.LiveTest do
         end
       end)
     end
+
+    test "triggers phx-change validations upon file selection", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#upload-change-form", fn session ->
+        upload(session, "Avatar", "test/files/elixir.jpg")
+      end)
+      |> assert_has("#upload-change-result", text: "phx-change triggered on file selection")
+    end
+
+    test "follows redirects from `:progress` events", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#upload-redirect-form", fn session ->
+        upload(session, "Redirect Avatar", "test/files/elixir.jpg")
+      end)
+      |> assert_path("/live/page_2")
+    end
   end
 
   describe "filling out full form with field functions" do


### PR DESCRIPTION
When a file is selected in the browser, phx-change is triggered on the form. This changes the behaviour of upload/4 to be closer to the browsers behaviour. 

BREAKING CHANGE: users who previously worked around this issue may have phx-change called twice.