### PR TITLE
Allow wildcards in assert_path

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1322,11 +1322,11 @@ defmodule PhoenixTest do
   |> visit("/users")
   |> assert_path("/users", query_params: %{name: "frodo"})
 
-  # assert we're at a path with a wildcard
+  # assert we're at a path with a wildcard. The wildcard represents a single part of the path.
   conn
-  |> visit("/")
-  |> click("new chat room")
-  |> assert_path("/chat/*")
+  |> visit("/users")
+  |> click("Any User")
+  |> assert_path("/users/*/profile")
   ```
   """
   defdelegate assert_path(session, path), to: Driver

--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1321,6 +1321,12 @@ defmodule PhoenixTest do
   conn
   |> visit("/users")
   |> assert_path("/users", query_params: %{name: "frodo"})
+
+  # assert we're at a path with a wildcard
+  conn
+  |> visit("/")
+  |> click("new chat room")
+  |> assert_path("/chat/*")
   ```
   """
   defdelegate assert_path(session, path), to: Driver

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -212,15 +212,11 @@ defmodule PhoenixTest.Assertions do
     |> assert_query_params(params)
   end
 
-  defp path_to_list(path) do
-    String.split(path, "/")
-  end
-
   defp path_matches?(path, path), do: true
 
   defp path_matches?(expected, is) do
-    parts_expected = path_to_list(expected)
-    parts_is = path_to_list(is)
+    parts_expected = String.split(expected, "/")
+    parts_is = String.split(is, "/")
 
     if Enum.count(parts_expected) != Enum.count(parts_is) do
       false

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -191,7 +191,7 @@ defmodule PhoenixTest.Assertions do
   def assert_path(session, path) do
     uri = URI.parse(PhoenixTest.Driver.current_path(session))
 
-    if path_compare(path, uri.path) == :eq do
+    if path_matches?(path, uri.path) do
       assert true
     else
       msg = """
@@ -216,20 +216,20 @@ defmodule PhoenixTest.Assertions do
     String.split(path, "/")
   end
 
-  defp path_compare(path, path), do: :eq
+  defp path_matches?(path, path), do: true
 
-  defp path_compare(expected, is) do
+  defp path_matches?(expected, is) do
     parts_expected = path_to_list(expected)
     parts_is = path_to_list(is)
 
     if Enum.count(parts_expected) != Enum.count(parts_is) do
-      :neq
+      false
     else
       parts_not_matching =
         Enum.zip(parts_expected, parts_is)
         |> Enum.filter(fn {expect, is} -> uri_parts_match?(expect, is) == false end)
 
-      if parts_not_matching == [], do: :eq, else: :neq
+      parts_not_matching == []
     end
   end
 

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -222,7 +222,8 @@ defmodule PhoenixTest.Assertions do
       false
     else
       parts_not_matching =
-        Enum.zip(parts_expected, parts_is)
+        parts_expected
+        |> Enum.zip(parts_is)
         |> Enum.filter(fn {expect, is} -> uri_parts_match?(expect, is) == false end)
 
       parts_not_matching == []

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -586,6 +586,12 @@ defmodule PhoenixTest.AssertionsTest do
       assert_path(session, "/page/index", query_params: %{"hello" => "world"})
     end
 
+    test "asserts wildcard in expected path" do
+      session = %Live{current_path: "/user/12345/profile"}
+
+      assert_path(session, "/user/*/profile")
+    end
+
     test "order of query params does not matter" do
       session = %Live{current_path: "/page/index?hello=world&foo=bar"}
 


### PR DESCRIPTION
## Why

To cover scenarios where a user interaction creates a temporary entity which is referred to in the path.

## How

Allow wildcards in `assert_path`.

## What

Example:
```elixir
conn
|> visit("/")
|> click("new chat room")
|> assert_path("/chat/*")
```

Each wildcard `*` maps to exactly one part in the uri, so

`/user/*/profile` will accept `/user/123/profile`, but not `/user/profile` or `/user/123/public/profile`