### PR TITLE
fix: :bug: pass non-redirect error tuples through `maybe_redirect`

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -112,10 +112,15 @@ defmodule PhoenixTest.Live do
   end
 
   def within(session, selector, fun) when is_function(fun, 1) do
-    session
-    |> Map.put(:within, selector)
-    |> fun.()
-    |> Map.put(:within, :none)
+    result =
+      session
+      |> Map.put(:within, selector)
+      |> fun.()
+
+    case result do
+      %{} -> Map.put(result, :within, :none)
+      {:error, _} -> result
+    end
   end
 
   def fill_in(session, label, opts) do
@@ -394,6 +399,10 @@ defmodule PhoenixTest.Live do
     result
     |> follow_redirect(ConnHandler.recycle_all_headers(conn))
     |> maybe_redirect(session)
+  end
+
+  defp maybe_redirect({:error, _} = error, _session) do
+    error
   end
 
   defp maybe_redirect({:ok, view, _}, session) do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -782,6 +782,17 @@ defmodule PhoenixTest.LiveTest do
         submit(session)
       end
     end
+
+    test "returns errors (that are not redirects) to the user", %{conn: conn} do
+      file_type_error =
+        conn
+        |> visit("/live/index")
+        |> within("#full-form", fn session ->
+          upload(session, "Avatar", "test/files/phoenix.png")
+        end)
+
+      assert {:error, [[_, :not_accepted]]} = file_type_error
+    end
   end
 
   describe "filling out full form with field functions" do


### PR DESCRIPTION
`render_upload` can emit errors that are not redirects. This changes `maybe_redirect` and `within` to allow passage of non-redirect errors to the end user.

Fixes #167