### PR TITLE
Fix: Don't fail if input was removed

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -340,8 +340,8 @@ defmodule PhoenixTest.Live do
     cond do
       Form.phx_submit?(form) ->
         session.view
-        |> form(selector, FormPayload.new(form_data))
-        |> render_submit(FormPayload.new(additional_data))
+        |> form(selector)
+        |> render_submit(FormPayload.new(form_data ++ additional_data))
         |> maybe_redirect(session)
 
       Form.has_action?(form) ->

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -926,13 +926,13 @@ defmodule PhoenixTest.LiveTest do
     end
 
     test "handles conditional input gracefully (filled, then removed)", %{conn: conn} do
-        conn
-        |> visit("/live/index")
-        |> fill_in("Other", with: "this input will now be removed")
-        |> submit()
-        |> check("Hide other")
-        |> submit()
-      end
+      conn
+      |> visit("/live/index")
+      |> fill_in("Other", with: "this input will now be removed")
+      |> submit()
+      |> check("Hide other")
+      |> submit()
+    end
   end
 
   describe "open_browser" do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -924,6 +924,15 @@ defmodule PhoenixTest.LiveTest do
         end)
       end
     end
+
+    test "handles conditional input gracefully (filled, then removed)", %{conn: conn} do
+        conn
+        |> visit("/live/index")
+        |> fill_in("Other", with: "this input will now be removed")
+        |> submit()
+        |> check("Hide other")
+        |> submit()
+      end
   end
 
   describe "open_browser" do

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -508,6 +508,11 @@ defmodule PhoenixTest.WebApp.IndexLive do
       <button phx-click="redirect-and-trigger-form">Redirect and trigger action</button>
       <button phx-click="navigate-and-trigger-form">Navigate and trigger action</button>
     </form>
+
+    <form id="conditional-inputs" phx-change="save-form" phx-submit="save-form">
+      <label><input name="hide_other" type="checkbox" value="on" />Hide other</label>
+      <label :if={@form_data["hide_other"] != "on"}>Other <input name="other" type="text" /></label>
+    </form>
     """
   end
 


### PR DESCRIPTION
In a LiveView, if
1. input A is filled
2. input A is removed from the DOM (e.g. because it is conditional, depending on some other input)
3. form is submitted

then an error is raised, because [form/3](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveViewTest.html#form/3) can't find the since-removed input.

Instead, the data should silently be omitted (actual browser behaviour).