### PR TITLE
fix: :bug: throw nice error messages for `render_upload` errors

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -273,7 +273,56 @@ defmodule PhoenixTest.Live do
     session.view
     |> file_input(form.selector, live_upload_name, [entry])
     |> render_upload(file_name)
+    |> maybe_throw_upload_errors(session, file_name, live_upload_name)
     |> maybe_redirect(session)
+  end
+
+  defp maybe_throw_upload_errors({:error, [[_id, error]]}, session, file_name, live_upload_name) do
+    case error do
+      :not_accepted -> raise ArgumentError, message: not_accepted_error_msg(session, file_name, live_upload_name)
+      :too_many_files -> raise ArgumentError, message: too_many_files_error_msg(session, file_name, live_upload_name)
+      :too_large -> raise ArgumentError, message: too_large_error_msg(session, file_name, live_upload_name)
+    end
+  end
+
+  defp maybe_throw_upload_errors(session_or_redirect, _session, _file_name, _live_upload_name) do
+    session_or_redirect
+  end
+
+  defp not_accepted_error_msg(session, file_name, live_upload_name) do
+    allowed_list =
+      session.conn.assigns.uploads[live_upload_name].acceptable_exts
+      |> MapSet.to_list()
+      |> Enum.join(", ")
+
+    """
+    Unsupported file type.
+
+    You were trying to upload "#{file_name}",
+    but the only file types specified in `allow_upload` are [#{allowed_list}].
+    """
+  end
+
+  defp too_many_files_error_msg(session, file_name, live_upload_name) do
+    %{name: name, max_entries: max_entries} = session.conn.assigns.uploads[live_upload_name]
+
+    """
+    Too many files uploaded.
+
+    While attempting to upload "#{file_name}", you've exceeded #{max_entries} file(s). If this is intentional,
+    consider updating `allow_upload(:#{name}, max_entries: #{max_entries})`.
+    """
+  end
+
+  defp too_large_error_msg(session, file_name, live_upload_name) do
+    %{name: name, max_file_size: max_file_size} = session.conn.assigns.uploads[live_upload_name]
+
+    """
+    File too large.
+
+    While attempting to upload "#{file_name}", you've exceeded the maximum file size of #{max_file_size} bytes. If this is intentional,
+    consider updating `allow_upload(:#{name}, max_file_size: #{max_file_size})`.
+    """
   end
 
   defp fill_in_field_data(session, field) do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -782,6 +782,37 @@ defmodule PhoenixTest.LiveTest do
         submit(session)
       end
     end
+
+    test "throws a nice error message for the `:not_accepted` error", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#full-form", fn session ->
+        assert_raise ArgumentError, ~r/Unsupported file type/, fn ->
+          upload(session, "Avatar", "test/files/phoenix.png")
+        end
+      end)
+    end
+
+    test "throws a nice error message for the `:too_many_files` error", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#full-form", fn session ->
+        assert_raise ArgumentError, ~r/Too many files uploaded./, fn ->
+          upload(session, "Avatar", "test/files/elixir.jpg")
+          upload(session, "Avatar", "test/files/elixir.jpg")
+        end
+      end)
+    end
+
+    test "throws a nice error message for the `:too_large` error", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#tiny-upload-form", fn session ->
+        assert_raise ArgumentError, ~r/File too large./, fn ->
+          upload(session, "Tiny", "test/files/elixir.jpg")
+        end
+      end)
+    end
   end
 
   describe "filling out full form with field functions" do

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -508,6 +508,11 @@ defmodule PhoenixTest.WebApp.IndexLive do
       <button phx-click="redirect-and-trigger-form">Redirect and trigger action</button>
       <button phx-click="navigate-and-trigger-form">Navigate and trigger action</button>
     </form>
+
+    <form id="tiny-upload-form">
+      <label for={@uploads.tiny.ref}>Tiny</label>
+      <.live_file_input upload={@uploads.tiny} />
+    </form>
     """
   end
 
@@ -537,6 +542,7 @@ defmodule PhoenixTest.WebApp.IndexLive do
       |> allow_upload(:avatar, accept: ~w(.jpg .jpeg))
       |> allow_upload(:main_avatar, accept: ~w(.jpg .jpeg))
       |> allow_upload(:backup_avatar, accept: ~w(.jpg .jpeg))
+      |> allow_upload(:tiny, accept: ~w(.jpg .jpeg), max_file_size: 1000)
     }
   end
 


### PR DESCRIPTION
`render_upload` can emit errors that are not redirects. `upload/4` now throws nice errors for the following `render_upload` errors: [:too_large, :too_many_files, :not_accepted]. We let new/unknown errors simply fail at the case match so they can be implemented in the future. Sessions and redirects are passed through to `maybe_redirect` as before.

Fixes #167