### PR TITLE
Allow nesting of `within/3`

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -110,13 +110,6 @@ defmodule PhoenixTest.Live do
     end
   end
 
-  def within(session, selector, fun) when is_function(fun, 1) do
-    session
-    |> Map.put(:within, selector)
-    |> fun.()
-    |> Map.put(:within, :none)
-  end
-
   def fill_in(session, label, opts) do
     selectors = ["input:not([type='hidden'])", "textarea"]
     fill_in(session, selectors, label, opts)
@@ -492,6 +485,7 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   alias PhoenixTest.Assertions
   alias PhoenixTest.ConnHandler
   alias PhoenixTest.Live
+  alias PhoenixTest.SessionHelpers
 
   def visit(session, path) do
     ConnHandler.visit(session.conn, path)
@@ -503,7 +497,7 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   defdelegate click_link(session, selector, text), to: Live
   defdelegate click_button(session, text), to: Live
   defdelegate click_button(session, selector, text), to: Live
-  defdelegate within(session, selector, fun), to: Live
+  defdelegate within(session, selector, fun), to: SessionHelpers
   defdelegate fill_in(session, label, opts), to: Live
   defdelegate fill_in(session, input_selector, label, opts), to: Live
   defdelegate select(session, option, opts), to: Live

--- a/lib/phoenix_test/session_helpers.ex
+++ b/lib/phoenix_test/session_helpers.ex
@@ -1,0 +1,12 @@
+defmodule PhoenixTest.SessionHelpers do
+  @moduledoc false
+  def within(session, selector, fun) when is_binary(selector) and is_function(fun, 1) do
+    session
+    |> Map.update!(:within, fn
+      :none -> selector
+      parent when is_binary(parent) -> parent <> " " <> selector
+    end)
+    |> fun.()
+    |> Map.put(:within, :none)
+  end
+end

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -118,13 +118,6 @@ defmodule PhoenixTest.Static do
     end
   end
 
-  def within(session, selector, fun) when is_function(fun, 1) do
-    session
-    |> Map.put(:within, selector)
-    |> fun.()
-    |> Map.put(:within, :none)
-  end
-
   def fill_in(session, label, opts) do
     selectors = ["input:not([type='hidden'])", "textarea"]
     fill_in(session, selectors, label, opts)
@@ -326,6 +319,7 @@ end
 defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
   alias PhoenixTest.Assertions
   alias PhoenixTest.ConnHandler
+  alias PhoenixTest.SessionHelpers
   alias PhoenixTest.Static
 
   def visit(session, path) do
@@ -338,7 +332,7 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
   defdelegate click_link(session, selector, text), to: Static
   defdelegate click_button(session, text), to: Static
   defdelegate click_button(session, selector, text), to: Static
-  defdelegate within(session, selector, fun), to: Static
+  defdelegate within(session, selector, fun), to: SessionHelpers
   defdelegate fill_in(session, label, opts), to: Static
   defdelegate fill_in(session, input_selector, label, opts), to: Static
   defdelegate select(session, option, opts), to: Static

--- a/test/phoenix_test/session_helpers_test.exs
+++ b/test/phoenix_test/session_helpers_test.exs
@@ -1,0 +1,63 @@
+defmodule PhoenixTest.SessionHelpersTest do
+  use ExUnit.Case, async: true
+
+  import PhoenixTest.SessionHelpers, only: [within: 3]
+
+  describe "within" do
+    test "runs action provided inside within" do
+      initial = %{within: :none}
+
+      assert_raise RuntimeError, "hello world", fn ->
+        within(initial, "selector", fn _session ->
+          raise "hello world"
+        end)
+      end
+    end
+
+    test "updates selector scope inside within" do
+      initial = %{within: :none}
+
+      within(initial, "#email-form", fn session ->
+        assert session.within == "#email-form"
+        session
+      end)
+    end
+
+    test "scope is reset to :none outside of within call" do
+      initial = %{within: :none}
+
+      session =
+        within(initial, "#email-form", fn session ->
+          session
+        end)
+
+      assert session.within == :none
+    end
+
+    test "nests selector scopes when multiple withins" do
+      initial = %{within: :none}
+
+      within(initial, "main", fn session ->
+        within(session, "#email-form", fn session ->
+          assert session.within == "main #email-form"
+          session
+        end)
+      end)
+    end
+
+    test "selector scopes do not interfere with adjacent withins" do
+      initial = %{within: :none}
+
+      initial
+      |> within("#email-form", fn session ->
+        session
+      end)
+      |> within("body", fn session ->
+        within(session, "#user-form", fn session ->
+          assert session.within == "body #user-form"
+          session
+        end)
+      end)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #185 

What changed?
============

This updates `within/3` to be able to nest `within/3` for both Live and Static implementations.

Though not strictly required (since right now the last within always wins), it can be confusing if someone nests `within/3` and it unexpectedly finds something that would've been left out by the "outer" within.

As part of this work, we create a `SessionHelpers` module to keep the `within` implementation that was duplicated across `Live` and `Static`. It's not the best module name, but it works for now. It might attract more logic and get a better name in the future.