### PR TITLE
Simplify CI testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     name: Test on OTP ${{matrix.otp}} / Elixir ${{matrix.elixir}}
     strategy:
       matrix:
-        otp: ['26.1.2']
-        elixir: ['1.15.0', '1.16.0', '1.17.0', '1.18.0']
+        otp: ['27.2']
+        elixir: ['1.17', '1.18']
     steps:
     - name: Set up Elixir
       uses: erlef/setup-beam@v1


### PR DESCRIPTION
We drop Elixir 1.15 and 1.16 so we can rely on OTP 27.