### PR TITLE
Deprecate `select` with `:from` in favor of `:option`

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -214,7 +214,7 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> Plug.Conn.put_req_header("x-auth-header", "Some-Value")
       |> visit("/auth/live/index")
-      |> within("#live-redirect-form", &select(&1, "Two", from: "Name"))
+      |> within("#live-redirect-form", &select(&1, "Name", option: "Two"))
       |> assert_path("/auth/live/page_2")
       |> assert_has("#flash-group", text: "Redirected on phx-change")
       |> then(fn %{conn: conn} ->
@@ -430,21 +430,21 @@ defmodule PhoenixTest.LiveTest do
     test "selects given option for a label", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("Elf", from: "Race")
+      |> select("Race", option: "Elf")
       |> assert_has("#full-form option[value='elf']")
     end
 
     test "allows selecting option if a similar option exists", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("Orc", from: "Race")
+      |> select("Race", option: "Orc")
       |> assert_has("#full-form option[value='orc']")
     end
 
     test "works in 'nested' forms", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("False", from: "User Admin")
+      |> select("User Admin", option: "False")
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:admin: false")
     end
@@ -452,7 +452,7 @@ defmodule PhoenixTest.LiveTest do
     test "can be used to submit form", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("Elf", from: "Race")
+      |> select("Race", option: "Elf")
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "race: elf")
     end
@@ -460,8 +460,8 @@ defmodule PhoenixTest.LiveTest do
     test "works for multiple select", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("Elf", from: "Race")
-      |> select(["Elf", "Dwarf"], from: "Race 2")
+      |> select("Race", option: "Elf")
+      |> select("Race 2", option: ["Elf", "Dwarf"])
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "[elf, dwarf]")
     end
@@ -470,7 +470,7 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> visit("/live/index")
       |> within("#not-a-form", fn session ->
-        select(session, "Dog", from: "Choose a pet:")
+        select(session, "Choose a pet:", option: "Dog")
       end)
       |> assert_has("#form-data", text: "selected: [dog]")
     end
@@ -479,7 +479,7 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> visit("/live/index")
       |> within("#not-a-form", fn session ->
-        select(session, ["Dog", "Cat"], from: "Choose a pet:")
+        select(session, "Choose a pet:", option: ["Dog", "Cat"])
       end)
       |> assert_has("#form-data", text: "selected: [dog, cat]")
     end
@@ -488,7 +488,7 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> visit("/live/index")
       |> within("#complex-labels", fn session ->
-        select(session, "Dog", from: "Choose a pet:", exact: false)
+        select(session, "Choose a pet:", exact: false, option: "Dog")
       end)
       |> assert_has("#form-data", text: "pet: dog")
     end
@@ -497,7 +497,7 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> visit("/live/index")
       |> within("#full-form", fn session ->
-        select(session, "Hum", from: "Race", exact_option: false)
+        select(session, "Race", exact_option: false, option: "Hum")
       end)
       |> submit()
       |> assert_has("#form-data", text: "race: human")
@@ -507,7 +507,7 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> visit("/live/index")
       |> within("#same-labels", fn session ->
-        select(session, "#select-favorite-character", "Frodo", from: "Character")
+        select(session, "#select-favorite-character", "Character", option: "Frodo")
       end)
       |> assert_has("#form-data", text: "favorite-character: Frodo")
     end
@@ -516,7 +516,7 @@ defmodule PhoenixTest.LiveTest do
       session = visit(conn, "/live/index")
 
       assert_raise ArgumentError, ~r/to have a valid `phx-click` attribute on options or to belong to a `form`/, fn ->
-        select(session, "Dog", from: "Invalid Select Option")
+        select(session, "Invalid Select Option", option: "Dog")
       end
     end
   end
@@ -799,7 +799,7 @@ defmodule PhoenixTest.LiveTest do
       |> fill_in("First Name", with: "Legolas")
       |> fill_in("Date", with: Date.new!(2023, 12, 30))
       |> check("Admin")
-      |> select("Elf", from: "Race")
+      |> select("Race", option: "Elf")
       |> choose("Email Choice")
       |> fill_in("Notes", with: "Woodland Elf")
       |> click_button("Save Full Form")
@@ -815,7 +815,7 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> visit("/live/index")
       |> fill_in("User Name", with: "Legolas")
-      |> select("True", from: "User Admin")
+      |> select("User Admin", option: "True")
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:name: Legolas")
       |> assert_has("#form-data", text: "user:admin: true")

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -446,7 +446,7 @@ defmodule PhoenixTest.StaticTest do
     test "selects given option for a label", %{conn: conn} do
       conn
       |> visit("/page/index")
-      |> select("Elf", from: "Race")
+      |> select("Race", option: "Elf")
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "race: elf")
     end
@@ -461,14 +461,14 @@ defmodule PhoenixTest.StaticTest do
     test "allows selecting option if a similar option exists", %{conn: conn} do
       conn
       |> visit("/page/index")
-      |> select("Orc", from: "Race")
+      |> select("Race", option: "Orc")
       |> assert_has("#full-form option[value='orc']")
     end
 
     test "works in 'nested' forms", %{conn: conn} do
       conn
       |> visit("/page/index")
-      |> select("False", from: "User Admin")
+      |> select("User Admin", option: "False")
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:admin: false")
     end
@@ -476,7 +476,7 @@ defmodule PhoenixTest.StaticTest do
     test "handles multi select", %{conn: conn} do
       conn
       |> visit("/page/index")
-      |> select(["Elf", "Dwarf"], from: "Race 2")
+      |> select("Race 2", option: ["Elf", "Dwarf"])
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "race_2: [elf,dwarf]")
     end
@@ -492,7 +492,7 @@ defmodule PhoenixTest.StaticTest do
       conn
       |> visit("/page/index")
       |> within("#complex-labels", fn session ->
-        select(session, "Dog", from: "Choose a pet:", exact: false)
+        select(session, "Choose a pet:", exact: false, option: "Dog")
       end)
       |> submit()
       |> assert_has("#form-data", text: "pet: dog")
@@ -502,7 +502,7 @@ defmodule PhoenixTest.StaticTest do
       conn
       |> visit("/page/index")
       |> within("#full-form", fn session ->
-        select(session, "Hum", from: "Race", exact_option: false)
+        select(session, "Race", exact_option: false, option: "Hum")
       end)
       |> submit()
       |> assert_has("#form-data", text: "race: human")
@@ -512,7 +512,7 @@ defmodule PhoenixTest.StaticTest do
       conn
       |> visit("/page/index")
       |> within("#same-labels", fn session ->
-        select(session, "#select-favorite-character", "Frodo", from: "Character")
+        select(session, "#select-favorite-character", "Character", option: "Frodo")
       end)
       |> submit()
       |> assert_has("#form-data", text: "favorite-character: Frodo")
@@ -715,7 +715,7 @@ defmodule PhoenixTest.StaticTest do
       |> fill_in("First Name", with: "Legolas")
       |> fill_in("Date", with: Date.new!(2023, 12, 30))
       |> check("Admin")
-      |> select("Elf", from: "Race")
+      |> select("Race", option: "Elf")
       |> choose("Email Choice")
       |> fill_in("Notes", with: "Woodland Elf")
       |> click_button("Save Full Form")
@@ -731,7 +731,7 @@ defmodule PhoenixTest.StaticTest do
       conn
       |> visit("/page/index")
       |> fill_in("User Name", with: "Legolas")
-      |> select("True", from: "User Admin")
+      |> select("User Admin", option: "True")
       |> click_button("Save Nested Form")
       |> assert_has("#form-data", text: "user:name: Legolas")
       |> assert_has("#form-data", text: "user:admin: true")

--- a/test/phoenix_test_test.exs
+++ b/test/phoenix_test_test.exs
@@ -1,0 +1,35 @@
+defmodule PhoenixTestTest do
+  use ExUnit.Case, async: true
+
+  import PhoenixTest
+
+  setup do
+    %{conn: Phoenix.ConnTest.build_conn()}
+  end
+
+  describe "select/3" do
+    test "shows deprecation warning when using :from", %{conn: conn} do
+      message =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          conn
+          |> visit("/live/index")
+          |> select("Elf", from: "Race")
+        end)
+
+      assert message =~ "select/3 with :from is deprecated"
+    end
+  end
+
+  describe "select/4" do
+    test "shows deprecation warning if passing `:from`", %{conn: conn} do
+      message =
+        ExUnit.CaptureIO.capture_io(:stderr, fn ->
+          conn
+          |> visit("/live/index")
+          |> select("#select-favorite-character", "Frodo", from: "Character")
+        end)
+
+      assert message =~ "select/4 with :from is deprecated"
+    end
+  end
+end

--- a/upgrade_guides.md
+++ b/upgrade_guides.md
@@ -1,6 +1,44 @@
 Upgrade Guides
 ==============
 
+## Upgrading to 0.5.3
+
+Version 0.5.3 deprecates `select/3` and `select/4` using `:from` to denote the
+label. Instead, it expects the label text to be passed as a positional argument
+and an `:option` keyword argument to pass the option's text.
+
+Thus, you'll need to make this change:
+
+```diff
+- |> select("Option 1", from: "Select Label")
++ |> select("Select Label", option: "Option 1")
+```
+
+And if you're using the version that provides a CSS selector:
+
+```diff
+- |> select("#super-select", "Option 1", from: "Select Label")
++ |> select("#super-select", "Select Label", option: "Option 1")
+```
+
+### Why the change?
+
+It may seem like a silly change (basically swapping positions of label and
+option arguments), and in some ways it is. There's no real change in
+functionality. So I've been very hesitant to make this change for a while.
+
+The problem is that `select` is a bit surprising and confusing to use!
+
+All other form helpers take in the label first as a positional argument, and
+then any additional arguments (when they have them) go into a keyword list.
+
+But `select` breaks that convention. It causes people to have to do mental
+gymnastics to switch the order of arguments.
+
+Rather than live with confusion for the rest of our lives, it seems better to
+incur the cost right now, and then we can move on with all of our form helpers
+being consistent.
+
 ## Upgrading to 0.2.13
 
 Version 0.2.13 deprecates `fill_form/3` and `submit_form/3`.


### PR DESCRIPTION
Resolves #166 

What changed?
============

Our `select` form helper takes in the option text first, and then it takes the label text in a `:from` argument.

That is confusing since every other form helper takes in the label first (as a positional argument), and then takes the "other value" (when it has one) as a keyword list.

We did it like that because it seemed to read somewhat naturally, and because of previous art (that's how Capybara's API had it). But really, the confusion it causes isn't worth the way it reads.

So, we deprecate the `:from` key in favor of passing the option text in` :option`.

Thus, we have to change:

```diff
- |> select("Option 1", from: "Select Label")
+ |> select("Select Label", option: "Option 1")
```

For now, things don't break. We include a deprecation warning which will hopefully help people make the upgrade. We also include some information in the upgrade guides.

NOTE that this doesn't require Drivers to change yet. We'll follow up with that once we fully remove the `:from` option.