### PR TITLE
Include simple `phx-*` attributes in selectors

### DIFF
--- a/lib/phoenix_test/element.ex
+++ b/lib/phoenix_test/element.ex
@@ -3,11 +3,26 @@ defmodule PhoenixTest.Element do
 
   def build_selector({tag, attributes, _}) do
     Enum.reduce_while(attributes, tag, fn
-      {"id", id}, _ when is_binary(id) -> {:halt, "[id=#{inspect(id)}]"}
-      {"phx-" <> _rest, _}, acc -> {:cont, acc}
-      {"class", _}, acc -> {:cont, acc}
-      {k, v}, acc -> {:cont, acc <> "[#{k}=#{inspect(v)}]"}
+      {"id", id}, _ when is_binary(id) ->
+        {:halt, "[id=#{inspect(id)}]"}
+
+      {"phx-" <> _rest = phx_attr, value}, acc ->
+        if encoded_live_view_js?(value) do
+          {:cont, acc}
+        else
+          {:cont, acc <> "[#{phx_attr}=#{inspect(value)}]"}
+        end
+
+      {"class", _}, acc ->
+        {:cont, acc}
+
+      {k, v}, acc ->
+        {:cont, acc <> "[#{k}=#{inspect(v)}]"}
     end)
+  end
+
+  defp encoded_live_view_js?(value) do
+    value =~ "[["
   end
 
   def selector_has_id?(selector) when is_binary(selector) do

--- a/test/phoenix_test/element_test.exs
+++ b/test/phoenix_test/element_test.exs
@@ -33,11 +33,28 @@ defmodule PhoenixTest.ElementTest do
       assert ~s(input[type="text"][name="name"]) = selector
     end
 
-    test "ignores `phx-*` attributes when id isn't present" do
+    test "includes simple phx-* attributes when id isn't present" do
       data =
         Query.find!(
           """
-          <input phx-click="ignore-complex-liveview-js" type="text" name="name" />
+          <input phx-click="save-user" type="text" name="name" />
+          """,
+          "input"
+        )
+
+      selector = Element.build_selector(data)
+
+      assert ~s(input[phx-click="save-user"][type="text"][name="name"]) = selector
+    end
+
+    test "ignores complex `phx-*` LiveView.JS attributes when id isn't present" do
+      %{ops: data} = Phoenix.LiveView.JS.navigate("/live/page_2")
+      {:ok, encoded_action} = Jason.encode(data)
+
+      data =
+        Query.find!(
+          """
+          <input phx-click=#{encoded_action} type="text" name="name" />
           """,
           "input"
         )


### PR DESCRIPTION
Resolves #176 

What changed?
============

Our `Element.build_selector` function is used to create selectors for different elements. By default, it ignores `phx-*` attributes since they can are complex when they use LiveView.JS.

But sometimes people want to rely on the `phx-*` attribute to target elements. One example was when using them for `form` elements with `phx-submit`s that only have an event name.

So, we modify our `build_selector` function to include simple `phx-*` values by identifying LiveView.JS through a heuristic -- when it's json encoded, it has a `[[` to start.