### PR TITLE
`assert_path` handles query params with []

### DIFF
--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -238,12 +238,12 @@ defmodule PhoenixTest.Assertions do
     params = Utils.stringify_keys_and_values(params)
 
     uri = URI.parse(PhoenixTest.Driver.current_path(session))
-    query_params = uri.query && URI.decode_query(uri.query)
+    query_params = uri.query && Plug.Conn.Query.decode(uri.query)
 
     if query_params == params do
       assert true
     else
-      params_string = URI.encode_query(params)
+      params_string = Plug.Conn.Query.encode(params)
 
       msg = """
       Expected query params to be #{inspect(params_string)} but got #{inspect(uri.query)}

--- a/lib/phoenix_test/utils.ex
+++ b/lib/phoenix_test/utils.ex
@@ -4,7 +4,13 @@ defmodule PhoenixTest.Utils do
   def present?(term), do: !blank?(term)
   def blank?(term), do: term == nil || term == ""
 
-  def stringify_keys_and_values(map) do
-    Map.new(map, fn {k, v} -> {to_string(k), to_string(v)} end)
+  def stringify_keys_and_values(map) when is_map(map) do
+    Map.new(map, fn
+      {k, v} when is_list(v) ->
+        {to_string(k), Enum.map(v, &to_string/1)}
+
+      {k, v} ->
+        {to_string(k), to_string(v)}
+    end)
   end
 end

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -598,6 +598,12 @@ defmodule PhoenixTest.AssertionsTest do
       assert_path(session, "/page/index", query_params: %{"foo" => "bar", "hello" => "world"})
     end
 
+    test "handles query params that have a list as a value" do
+      session = %Live{current_path: "/page/index?users[]=frodo&users[]=sam"}
+
+      assert_path(session, "/page/index", query_params: %{"users" => ["frodo", "sam"]})
+    end
+
     test "raises helpful error if path doesn't match" do
       msg =
         ignore_whitespace("""
@@ -634,6 +640,16 @@ defmodule PhoenixTest.AssertionsTest do
         session = %Live{current_path: "/page/index?hello=world&hi=bye"}
 
         assert_path(session, "/page/index", query_params: %{"goodbye" => "world", "hi" => "bye"})
+      end
+    end
+
+    test "raises helpful error if path doesn't have query params with lists" do
+      session = %Live{current_path: "/page/index?users[]=frodo&users[]=sam"}
+
+      msg = ~r/Expected query params to be "users\[\]=sam" but/
+
+      assert_raise AssertionError, msg, fn ->
+        assert_path(session, "/page/index", query_params: %{"users" => ["sam"]})
       end
     end
   end

--- a/test/phoenix_test/utils_test.exs
+++ b/test/phoenix_test/utils_test.exs
@@ -1,0 +1,31 @@
+defmodule PhoenixTest.UtilsTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixTest.Utils
+
+  describe "stringify_keys_and_values" do
+    test "turns atom keys into string keys" do
+      original = %{hello: "world"}
+
+      result = Utils.stringify_keys_and_values(original)
+
+      assert %{"hello" => "world"} = result
+    end
+
+    test "turns values into string keys" do
+      original = %{value: :ok}
+
+      result = Utils.stringify_keys_and_values(original)
+
+      assert %{"value" => "ok"} = result
+    end
+
+    test "preserves lists and stringifies values" do
+      original = %{greet: [:hello, "hola"]}
+
+      result = Utils.stringify_keys_and_values(original)
+
+      assert %{"greet" => ["hello", "hola"]} = result
+    end
+  end
+end


### PR DESCRIPTION
Resolves #168

What changed?
============

We improve `assert_path` to handle query params that have lists.

There are many cases when we want to assert the query includes things like `users[]=frodo&users[]=sam`.

The assertion would present those as a list in the map:

```elixir
assert_path("/some/path", query_params: %{users: ["frodo", "sam"]})
```

This commit makes it so that we can do that.