### PR TITLE
Allow empty maps to be passed into assert_path as query_params

### DIFF
--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -240,16 +240,21 @@ defmodule PhoenixTest.Assertions do
     uri = URI.parse(PhoenixTest.Driver.current_path(session))
     query_params = uri.query && Plug.Conn.Query.decode(uri.query)
 
-    if query_params == params do
-      assert true
-    else
-      params_string = Plug.Conn.Query.encode(params)
+    cond do
+      query_params == params ->
+        assert true
 
-      msg = """
-      Expected query params to be #{inspect(params_string)} but got #{inspect(uri.query)}
-      """
+      is_nil(query_params) && params == %{} ->
+        assert true
 
-      raise AssertionError, msg
+      true ->
+        params_string = Plug.Conn.Query.encode(params)
+
+        msg = """
+        Expected query params to be #{inspect(params_string)} but got #{inspect(uri.query)}
+        """
+
+        raise AssertionError, msg
     end
 
     session

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -604,6 +604,12 @@ defmodule PhoenixTest.AssertionsTest do
       assert_path(session, "/page/index", query_params: %{"users" => ["frodo", "sam"]})
     end
 
+    test "handles asserting empty query params" do
+      session = %Live{current_path: "/page/index"}
+
+      assert_path(session, "/page/index", query_params: %{})
+    end
+
     test "raises helpful error if path doesn't match" do
       msg =
         ignore_whitespace("""


### PR DESCRIPTION
Initially, there was no way to assert that a path had no query params. If you passed into `assert_path` `query_params: ""` or `query_params: nil` you would get: `(FunctionClauseError) no function clause matching in PhoenixTest.Utils.stringify_keys_and_values/1` This is because `Utils.stringify_keys_and_values` is expecting a map.

If you passed in `query_params: %{}`, you would get: `Empty map results in "Expected query params to be "" but got nil.` This is because URI.parse returns `nil` when a query param is not present.

The fix is to assert true if either the query_params match the passed in expected params or if the parsed query_params are `nil` and the expected params are an empty map.