### PR TITLE
Fix: handle prefilled values for most input types

### DIFF
--- a/lib/phoenix_test/element/form.ex
+++ b/lib/phoenix_test/element/form.ex
@@ -68,20 +68,34 @@ defmodule PhoenixTest.Element.Form do
   defp descendant_selector(%{selector: selector, text: text}), do: {selector, text}
   defp descendant_selector(%{selector: selector}), do: selector
 
-  @text_like_types ~w(date datetime-local email month number password range search tel text time url week)
+  @simple_value_types ~w(
+    date
+    datetime-local
+    email
+    month
+    number
+    password
+    range
+    search
+    tel
+    text
+    time
+    url
+    week
+  )
 
   @hidden_inputs "input[type=hidden]"
   @checked_radio_buttons "input:not([disabled])[type=radio][checked=checked][value]"
   @checked_checkboxes "input:not([disabled])[type=checkbox][checked=checked][value]"
-  @pre_filled_text_like_inputs Enum.map_join(@text_like_types, ",", &"input:not([disabled])[type=#{&1}][value]")
   @pre_filled_default_text_inputs "input:not([disabled]):not([type])[value]"
+  @pre_filled_simple_value_inputs Enum.map_join(@simple_value_types, ",", &"input:not([disabled])[type=#{&1}][value]")
 
   defp form_data(form) do
     FormData.new()
     |> FormData.add_data(form_data(@hidden_inputs, form))
     |> FormData.add_data(form_data(@checked_radio_buttons, form))
     |> FormData.add_data(form_data(@checked_checkboxes, form))
-    |> FormData.add_data(form_data(@pre_filled_text_like_inputs, form))
+    |> FormData.add_data(form_data(@pre_filled_simple_value_inputs, form))
     |> FormData.add_data(form_data(@pre_filled_default_text_inputs, form))
     |> FormData.add_data(form_data_textarea(form))
     |> FormData.add_data(form_data_select(form))

--- a/lib/phoenix_test/element/form.ex
+++ b/lib/phoenix_test/element/form.ex
@@ -68,12 +68,12 @@ defmodule PhoenixTest.Element.Form do
   defp descendant_selector(%{selector: selector, text: text}), do: {selector, text}
   defp descendant_selector(%{selector: selector}), do: selector
 
+  @text_like_types ~w(date datetime-local email month number password range search tel text time url week)
+
   @hidden_inputs "input[type=hidden]"
   @checked_radio_buttons "input:not([disabled])[type=radio][checked=checked][value]"
   @checked_checkboxes "input:not([disabled])[type=checkbox][checked=checked][value]"
-  @pre_filled_text_inputs "input:not([disabled])[type=text][value]"
-  @pre_filled_number_inputs "input:not([disabled])[type=number][value]"
-  @pre_filled_email_inputs "input:not([disabled])[type=email][value]"
+  @pre_filled_text_like_inputs Enum.map_join(@text_like_types, ",", &"input:not([disabled])[type=#{&1}][value]")
   @pre_filled_default_text_inputs "input:not([disabled]):not([type])[value]"
 
   defp form_data(form) do
@@ -81,9 +81,7 @@ defmodule PhoenixTest.Element.Form do
     |> FormData.add_data(form_data(@hidden_inputs, form))
     |> FormData.add_data(form_data(@checked_radio_buttons, form))
     |> FormData.add_data(form_data(@checked_checkboxes, form))
-    |> FormData.add_data(form_data(@pre_filled_text_inputs, form))
-    |> FormData.add_data(form_data(@pre_filled_number_inputs, form))
-    |> FormData.add_data(form_data(@pre_filled_email_inputs, form))
+    |> FormData.add_data(form_data(@pre_filled_text_like_inputs, form))
     |> FormData.add_data(form_data(@pre_filled_default_text_inputs, form))
     |> FormData.add_data(form_data_textarea(form))
     |> FormData.add_data(form_data_select(form))

--- a/test/phoenix_test/element/form_test.exs
+++ b/test/phoenix_test/element/form_test.exs
@@ -105,9 +105,19 @@ defmodule PhoenixTest.Element.FormTest do
         <input type="hidden" name="method" value="delete"/>
         <input name="input" value="value" />
 
-        <input type="text" name="text-input" value="text value" />
-        <input type="number" name="number-input" value="123" />
+        <input type="date" name="date-input" value="date value" />
+        <input type="datetime-local" name="datetime-local-input" value="datetime-local value" />
         <input type="email" name="email-input" value="test@example.com" />
+        <input type="month" name="month-input" value="month value" />
+        <input type="number" name="number-input" value="123" />
+        <input type="password" name="password-input" value="password value" />
+        <input type="range" name="range-input" value="range value" />
+        <input type="search" name="search-input" value="search value" />
+        <input type="tel" name="tel-input" value="tel value" />
+        <input type="text" name="text-input" value="text value" />
+        <input type="time" name="time-input" value="time value" />
+        <input type="url" name="url-input" value="url value" />
+        <input type="week" name="week-input" value="week value" />
 
         <select name="select">
           <option value="not_selected">Not selected</option>
@@ -137,18 +147,29 @@ defmodule PhoenixTest.Element.FormTest do
       """
 
       form = Form.find!(html, "form")
+      form_data = form.form_data
 
-      assert FormData.has_data?(form.form_data, "method", "delete")
-      assert FormData.has_data?(form.form_data, "input", "value")
-      assert FormData.has_data?(form.form_data, "text-input", "text value")
-      assert FormData.has_data?(form.form_data, "number-input", "123")
-      assert FormData.has_data?(form.form_data, "email-input", "test@example.com")
-      assert FormData.has_data?(form.form_data, "select", "selected")
-      assert FormData.has_data?(form.form_data, "select_multiple[]", "select_1")
-      assert FormData.has_data?(form.form_data, "select_multiple[]", "select_2")
-      assert FormData.has_data?(form.form_data, "checkbox", "checked")
-      assert FormData.has_data?(form.form_data, "radio", "checked")
-      assert FormData.has_data?(form.form_data, "textarea", "Default text")
+      assert FormData.has_data?(form_data, "method", "delete")
+      assert FormData.has_data?(form_data, "input", "value")
+      assert FormData.has_data?(form_data, "date-input", "date value")
+      assert FormData.has_data?(form_data, "datetime-local-input", "datetime-local value")
+      assert FormData.has_data?(form_data, "email-input", "test@example.com")
+      assert FormData.has_data?(form_data, "month-input", "month value")
+      assert FormData.has_data?(form_data, "number-input", "123")
+      assert FormData.has_data?(form_data, "password-input", "password value")
+      assert FormData.has_data?(form_data, "range-input", "range value")
+      assert FormData.has_data?(form_data, "search-input", "search value")
+      assert FormData.has_data?(form_data, "tel-input", "tel value")
+      assert FormData.has_data?(form_data, "text-input", "text value")
+      assert FormData.has_data?(form_data, "time-input", "time value")
+      assert FormData.has_data?(form_data, "url-input", "url value")
+      assert FormData.has_data?(form_data, "week-input", "week value")
+      assert FormData.has_data?(form_data, "select", "selected")
+      assert FormData.has_data?(form_data, "select_multiple[]", "select_1")
+      assert FormData.has_data?(form_data, "select_multiple[]", "select_2")
+      assert FormData.has_data?(form_data, "checkbox", "checked")
+      assert FormData.has_data?(form_data, "radio", "checked")
+      assert FormData.has_data?(form_data, "textarea", "Default text")
     end
 
     test "does not include disabled inputs in form_data" do


### PR DESCRIPTION
Supersedes #178 

The core change was introduced in #178. This PR adds tests to those changes. 

GitHub doesn't let me rebase and push over that branch, so this PR was created to supersede #178 but includes those changes. 

What changed? 
===========

We update our `Form` parsing to include all prefilled values for most input types that are "simple" or "text-like" (contrary to, say, a checkbox that must be selected in order to get the prefilled `value`).
