### PR TITLE
feat: introduce `click` helper for liveviews

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -218,6 +218,30 @@ defmodule PhoenixTest do
   end
 
   @doc """
+  Clicks an element with the given selector. The clicked element needs to have
+  a `phx-click` attribute defined. However, the click helper has several limitations:
+
+  - it does not work for Static pages as it does not make sense in the context of a static view.
+  - it does not work with form elements (use the designated helpers like `check` etc. for that)
+
+  ## Examples
+
+  ```heex
+  <div phx-click="toggle" aria-label="toggle element">Element that toggles something</div>
+  <button class="toggle-panel" data-element-id="1">Element with class and data-element attribute</button>
+  ```
+
+  ```elixir
+  session
+  |> click("div[aria-label='toggle element']") # <- will match the aria label
+
+  session
+  |> click("button.toggle-panel[data-element-id='1']) # <- will match the element `button`, the class `.toggle-paenl` and the `data` attribute
+  ```
+  """
+  defdelegate click(session, selector), to: Driver
+
+  @doc """
   Clicks a link with given text (using a substring match) and performs the
   action.
 

--- a/lib/phoenix_test/driver.ex
+++ b/lib/phoenix_test/driver.ex
@@ -3,6 +3,7 @@ defprotocol PhoenixTest.Driver do
   def visit(initial_struct, path)
   def render_page_title(session)
   def render_html(session)
+  def click(session, selector)
   def click_link(session, text)
   def click_link(session, selector, text)
   def click_button(session, text)

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -54,6 +54,13 @@ defmodule PhoenixTest.Live do
     end
   end
 
+  def click(session, selector) do
+    session.view
+    |> element(selector)
+    |> render_click()
+    |> maybe_redirect(session)
+  end
+
   def click_link(session, selector \\ "a", text) do
     session.view
     |> element(selector, text)
@@ -491,6 +498,7 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
 
   defdelegate render_page_title(session), to: Live
   defdelegate render_html(session), to: Live
+  defdelegate click(session, selector), to: Live
   defdelegate click_link(session, text), to: Live
   defdelegate click_link(session, selector, text), to: Live
   defdelegate click_button(session, text), to: Live

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -52,6 +52,12 @@ defmodule PhoenixTest.Static do
     end
   end
 
+  def click(_session, _selector) do
+    %ArgumentError{
+      message: "`click` can not be used for static views. Use `click_link` or `click_button` etc."
+    }
+  end
+
   def click_link(session, selector \\ "a", text) do
     link =
       session
@@ -324,6 +330,7 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
 
   defdelegate render_page_title(session), to: Static
   defdelegate render_html(session), to: Static
+  defdelegate click(session, selector), to: Static
   defdelegate click_link(session, text), to: Static
   defdelegate click_link(session, selector, text), to: Static
   defdelegate click_button(session, text), to: Static

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -127,6 +127,38 @@ defmodule PhoenixTest.LiveTest do
     end
   end
 
+  describe "click/2" do
+    test "clicks a button by selector", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click("#show-tab-btn")
+      |> assert_has("#tab", text: "Tab title")
+    end
+
+    test "clicks a div by an aria label as selector", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click("[aria-label='toggle element']")
+      |> assert_has("#tab", text: "Tab title")
+    end
+
+    test "clicks a button by an element, class and data selector", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click("button.toggle-panel[data-element-id='1']")
+      |> assert_has("#tab", text: "Tab title")
+    end
+
+    test "clicks a link", %{conn: conn} do
+      session =
+        conn
+        |> visit("/live/index")
+        |> click("a#navigate-link")
+
+      assert PhoenixTest.Driver.current_path(session) == "/live/page_2?details=true&foo=bar"
+    end
+  end
+
   describe "click_button/2" do
     test "finds button by substring", %{conn: conn} do
       conn

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -7,7 +7,7 @@ defmodule PhoenixTest.WebApp.IndexLive do
     ~H"""
     <h1 id="title" class="title" data-role="title">LiveView main page</h1>
 
-    <.link navigate="/live/page_2?details=true&foo=bar">Navigate link</.link>
+    <.link navigate="/live/page_2?details=true&foo=bar" id="navigate-link">Navigate link</.link>
     <.link patch="/live/index?details=true&foo=bar">Patch link</.link>
     <.link href="/page/index?details=true&foo=bar">Navigate to non-liveview</.link>
 
@@ -28,6 +28,12 @@ defmodule PhoenixTest.WebApp.IndexLive do
     <button phx-click="change-page-title">Change page title</button>
 
     <button phx-click="show-tab">Show tab</button>
+
+    <button phx-click="show-tab" id="show-tab-btn">`button` element for the `click/2` test</button>
+    <div phx-click="show-tab" aria-label="toggle element">`div` element for the `click/2` test</div>
+    <button phx-click="show-tab" class="toggle-panel" data-element-id="1">
+      `div` element with a custom data-test attribute for the `click/2` test
+    </button>
 
     <div :if={@show_tab} id="tab">
       <h2>Tab title</h2>
@@ -205,7 +211,9 @@ defmodule PhoenixTest.WebApp.IndexLive do
       <label for={@uploads.avatar.ref}>Avatar</label>
       <.live_file_input upload={@uploads.avatar} />
 
-      <button type="submit" name="full_form_button" value="save">Save Full Form</button>
+      <button type="submit" name="full_form_button" value="save" id="click-submit-btn">
+        Save Full Form
+      </button>
     </form>
 
     <form id="redirect-form" phx-submit="save-redirect-form">


### PR DESCRIPTION
# Overview

Adds a `click/2` helper which can be used to click on elements that have a `phx-click` attribute.

Will raise an error when being used in a static view.

## Background
It is not realistic that we have a label in every button when we can use `aria-label` for this very purpose. This helper allows you to write more meaningful tests:

```html
<!-- You can write this -->
<button aria-label="toggle-menu" phx-click="toggle-menu">
  <.icon name="some-icon" />
</button>

<!-- Instead of this -->
<button phx-click="toggle-menu">
  <span class="sr-only">toggle menu</span>
  <.icon name="some-icon" />
</button>

<!-- you can also click div elements but that is somewhat debatable -->
<div phx-click="toggle-menu">
  <.icon name="some-icon" />
</div

```