### PR TITLE
Adds asserting & refuting by `:value`

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1279,7 +1279,11 @@ defmodule PhoenixTest do
   - `exact`: by default `assert_has/3` will perform a substring match (e.g. `a
   =~ b`). That makes it easier to assert text within HTML elements that also
   contain other HTML elements. But sometimes we want to assert the exact text is
-  present. For that, use `exact: true`. (defaults to `false`)
+  present. For that, use `exact: true`. Note: this only works with the `:text`
+  option. (defaults to `false`)
+
+  - `value`: the element's value to look for. Note that you cannot specify both
+  `text` and `value` as options.
 
   - `count`: the number of items you expect to match CSS selector (and `text` if
   provided)
@@ -1301,6 +1305,9 @@ defmodule PhoenixTest do
   # assert there's an element with ID "user" and text "Aragorn"
   assert_has(session, "#user", text: "Aragorn", exact: true)
     # ^ succeeds only if text found is "Aragorn". Fails if finds "Aragorn, Son of Arathorn"
+
+  # assert there's an input with value "Frodo"
+  assert_has(session, "input", value: "Frodo")
 
   # assert there are two elements with class "posts"
   assert_has(session, ".posts", count: 2)
@@ -1353,7 +1360,11 @@ defmodule PhoenixTest do
   - `exact`: by default `refute_has/3` will perform a substring match (e.g. `a
   =~ b`). That makes it easier to refute text within HTML elements that also
   contain other HTML elements. But sometimes we want to refute the exact text is
-  absent. For that, use `exact: true`.
+  absent. For that, use `exact: true`. Note: this only works with the `:text`
+  option.
+
+  - `value`: the element's value to look for. Note that you cannot specify both
+  `text` and `value` as options.
 
   - `count`: the number of items you're expecting _should not_ match the CSS
   selector (and `text` if provided)
@@ -1373,6 +1384,9 @@ defmodule PhoenixTest do
 
   # refute there's an element with ID "user" and exact text "Aragorn"
   refute_has(session, "#user", text: "Aragorn", exact: true)
+
+  # refute there's an input with value "Frodo"
+  refute_has(session, "input", value: "Frodo")
 
   # refute there are two elements with class "posts" (less or more will not raise)
   refute_has(session, ".posts", count: 2)

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -99,6 +99,30 @@ defmodule PhoenixTest.AssertionsTest do
       |> assert_has("h1", text: "Unauthorized")
     end
 
+    test "succeeds when asserting by value", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> assert_has("input", value: "Frodo")
+    end
+
+    test "raises an error if value can not be found", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      msg = ~r/Could not find any elements with selector "input" and value "does-not-exist"/
+
+      assert_raise AssertionError, msg, fn ->
+        assert_has(session, "input", value: "does-not-exist")
+      end
+    end
+
+    test "raises if user provides :text and :value options", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      assert_raise ArgumentError, ~r/Cannot provide both :text and :value/, fn ->
+        assert_has(session, "div", text: "some text", value: "some value")
+      end
+    end
+
     test "raises an error if the element cannot be found at all", %{conn: conn} do
       conn = visit(conn, "/page/index")
 
@@ -569,6 +593,30 @@ defmodule PhoenixTest.AssertionsTest do
         conn
         |> visit("/page/index")
         |> refute_has("#multiple-items li", at: 2, text: "Legolas")
+      end
+    end
+
+    test "can refute by value", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> refute_has("input", value: "not-frodo")
+    end
+
+    test "raises an error if value is found", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      msg = ~r/not to find any elements with selector "input" and value "Frodo"/
+
+      assert_raise AssertionError, msg, fn ->
+        refute_has(session, "input", value: "Frodo")
+      end
+    end
+
+    test "raises if user provides :text and :value options", %{conn: conn} do
+      session = visit(conn, "/page/index")
+
+      assert_raise ArgumentError, ~r/Cannot provide both :text and :value/, fn ->
+        refute_has(session, "div", text: "some text", value: "some value")
       end
     end
   end

--- a/test/support/web_app/page_view.ex
+++ b/test/support/web_app/page_view.ex
@@ -375,6 +375,15 @@ defmodule PhoenixTest.WebApp.PageView do
     """
   end
 
+  def render("by_value.html", assigns) do
+    ~H"""
+    <h1>Find by value</h1>
+    <form action="/">
+      <input type="text" name="user" value="Frodo" />
+    </form>
+    """
+  end
+
   def render("get_record.html", assigns) do
     ~H"""
     <h1>Record received</h1>


### PR DESCRIPTION
Resolves #181 

What changed?
============

We introduce a new `:value` option to `assert_has/3` and `refute_has/3`.

It allows us to make assertions about the value of an `<input>`, `<option>`, etc. That's mostly helpful when we want to check the state of an input.

The option cannot be combined with `:text` (we raise), and it isn't compatible with `:exact` (the value is always expected to be exact).

Aside from that, all other options are allowed (e.g. `:count`, `:at`, etc.)