### PR TITLE
Handles LiveView forms that remove elements

### DIFF
--- a/lib/phoenix_test/element/form.ex
+++ b/lib/phoenix_test/element/form.ex
@@ -50,6 +50,13 @@ defmodule PhoenixTest.Element.Form do
     }
   end
 
+  def form_element_names(%__MODULE__{} = form) do
+    form.raw
+    |> Html.all("[name]")
+    |> Enum.map(&Html.attribute(&1, "name"))
+    |> Enum.uniq()
+  end
+
   def phx_change?(form) do
     form.parsed
     |> Html.attribute("phx-change")

--- a/lib/phoenix_test/form_data.ex
+++ b/lib/phoenix_test/form_data.ex
@@ -47,6 +47,13 @@ defmodule PhoenixTest.FormData do
     %__MODULE__{data: data1 ++ data2}
   end
 
+  def filter(%__MODULE__{data: data}, fun) do
+    data =
+      Enum.filter(data, fn {name, value} -> fun.(%{name: name, value: value}) end)
+
+    %__MODULE__{data: data}
+  end
+
   def empty?(%__MODULE__{data: data}) do
     Enum.empty?(data)
   end

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -366,6 +366,7 @@ defmodule PhoenixTest.Live do
       |> render_html()
       |> Form.find!(selector)
 
+    form_data = remove_data_for_fields_that_have_been_removed(form_data, form)
     form_data = FormData.merge(form.form_data, form_data)
 
     additional_data =
@@ -393,6 +394,14 @@ defmodule PhoenixTest.Live do
         raise ArgumentError,
               "Expected form with selector #{inspect(selector)} to have a `phx-submit` or `action` defined."
     end
+  end
+
+  defp remove_data_for_fields_that_have_been_removed(form_data, form) do
+    element_names = Form.form_element_names(form)
+
+    FormData.filter(form_data, fn %{name: name} ->
+      name in element_names
+    end)
   end
 
   def open_browser(%{view: view} = session, open_fun \\ &Phoenix.LiveViewTest.open_browser/1) do

--- a/test/phoenix_test/element/form_test.exs
+++ b/test/phoenix_test/element/form_test.exs
@@ -342,4 +342,46 @@ defmodule PhoenixTest.Element.FormTest do
       assert form.method == "put"
     end
   end
+
+  describe "form_element_names/1" do
+    test "returns list of names for all inputs, selects, texareas, etc." do
+      html = """
+      <form>
+        <input type="hidden" name="method" value="delete"/>
+        <input name="some_input" value="value" />
+        <select name="some_select">
+          <option value="a">A</option>
+          <option value="b" selected>B</option>
+        </select>
+
+        <select multiple name="select_multiple[]">
+          <option value="select_1" selected>Selected 1</option>
+          <option value="select_2" selected>Selected 2</option>
+          <option value="select_3">Not Selected</option>
+        </select>
+
+        <input name="some_checkbox" type="checkbox" value="not_checked" />
+        <input name="some_checkbox" type="checkbox" value="checked" checked />
+
+        <input name="some_radio" type="radio" value="not_checked" />
+        <input name="some_radio" type="radio" value="checked" checked />
+
+        <textarea name="some_textarea">
+          Default text
+        </textarea>
+      </form>
+      """
+
+      form = Form.find!(html, "form")
+      names = Form.form_element_names(form)
+
+      assert "method" in names
+      assert "some_input" in names
+      assert "some_select" in names
+      assert "select_multiple[]" in names
+      assert "some_checkbox" in names
+      assert "some_radio" in names
+      assert "some_textarea" in names
+    end
+  end
 end

--- a/test/phoenix_test/form_data_test.exs
+++ b/test/phoenix_test/form_data_test.exs
@@ -121,6 +121,23 @@ defmodule PhoenixTest.FormDataTest do
     end
   end
 
+  describe "filter" do
+    test "filters form data based on function provivded" do
+      form_data =
+        FormData.new()
+        |> FormData.add_data("name", "frodo")
+        |> FormData.add_data("email", "frodo@fellowship.com")
+
+      filtered_data =
+        FormData.filter(form_data, fn %{name: name, value: value} ->
+          name == "name" and value == "frodo"
+        end)
+
+      assert FormData.has_data?(filtered_data, "name", "frodo")
+      refute FormData.has_data?(filtered_data, "email", "frodo@fellowship.com")
+    end
+  end
+
   describe "to_list" do
     test "transforms FormData into a list" do
       form_data =

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -909,6 +909,18 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "button: save")
     end
 
+    test "handles inputs that get removed through other actions without raising error", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_in("To keep", with: "this input should stay")
+      |> fill_in("To remove", with: "this input will now be removed")
+      |> submit()
+      |> check("Hide to remove")
+      |> submit()
+      |> assert_has("#form-data", text: "this input should stay")
+      |> refute_has("#form-data", text: "this input will now be removed")
+    end
+
     test "raises an error if there's no active form", %{conn: conn} do
       message = ~r/There's no active form. Fill in a form with `fill_in`, `select`, etc./
 

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -515,6 +515,18 @@ defmodule PhoenixTest.WebApp.IndexLive do
       <label for={@uploads.tiny.ref}>Tiny</label>
       <.live_file_input upload={@uploads.tiny} />
     </form>
+
+    <form id="conditional-inputs" phx-change="save-form" phx-submit="save-form">
+      <label>
+        <input name="hide_to_remove" type="checkbox" value="on" /> Hide to remove
+      </label>
+      <label :if={@form_data["hide_to_remove"] != "on"}>
+        To remove <input name="to_remove" type="text" />
+      </label>
+      <label>
+        To keep <input name="to_keep" type="text" />
+      </label>
+    </form>
     """
   end
 


### PR DESCRIPTION
Supersedes #171 and fixes #170

What changed?
============

Contrary to Static forms, LiveView forms can dynamically remove inputs, selects, etc.

Right now our form submission assumes every input that has been filled (or defaulted) should remain when we submit the form. But that doesn't handle the case when the form changes as a result of user's behavior on the page.

This commit fixes that by comparing the form's elements right before submission with the data that we have gathered from user interactions. If the form no longer has a field with that `name` on it, we remove it from the form submission (assuming it's been removed one way or another).