### PR TITLE
Do not raise non-existent path if URL is external

### DIFF
--- a/lib/phoenix_test/conn_handler.ex
+++ b/lib/phoenix_test/conn_handler.ex
@@ -11,23 +11,21 @@ defmodule PhoenixTest.ConnHandler do
   end
 
   def visit(conn) do
-    if route_exists?(conn) do
-      case conn do
-        %{assigns: %{live_module: _}} = conn ->
-          PhoenixTest.Live.build(conn)
+    verify_when_local_path!(conn)
 
-        %{status: 302} = conn ->
-          path = redirected_to(conn)
+    case conn do
+      %{assigns: %{live_module: _}} = conn ->
+        PhoenixTest.Live.build(conn)
 
-          conn
-          |> recycle_all_headers()
-          |> visit(path)
+      %{status: 302} = conn ->
+        path = redirected_to(conn)
 
-        conn ->
-          PhoenixTest.Static.build(conn)
-      end
-    else
-      raise ArgumentError, message: "#{inspect(conn.request_path)} path doesn't exist"
+        conn
+        |> recycle_all_headers()
+        |> visit(path)
+
+      conn ->
+        PhoenixTest.Static.build(conn)
     end
   end
 
@@ -42,6 +40,17 @@ defmodule PhoenixTest.ConnHandler do
 
   defp all_headers(conn) do
     Enum.map(conn.req_headers, &elem(&1, 0))
+  end
+
+  defp verify_when_local_path!(conn) do
+    if local_path?(conn) && !route_exists?(conn) do
+      raise ArgumentError, message: "#{inspect(conn.request_path)} path doesn't exist"
+    end
+  end
+
+  @plug_adapters_test_conn_default_host "www.example.com"
+  defp local_path?(conn) do
+    conn.host == @plug_adapters_test_conn_default_host or conn.host == @endpoint.host()
   end
 
   defp route_exists?(conn) do

--- a/test/phoenix_test/conn_handler_test.exs
+++ b/test/phoenix_test/conn_handler_test.exs
@@ -53,10 +53,14 @@ defmodule PhoenixTest.ConnHandlerTest do
       end)
     end
 
-    test "raises error if route doesn't exist", %{conn: conn} do
+    test "raises error if app route doesn't exist", %{conn: conn} do
       assert_raise ArgumentError, ~r/path doesn't exist/, fn ->
         ConnHandler.visit(conn, "/non_route")
       end
+    end
+
+    test "does not raise error if url is external (typically a redirect)", %{conn: conn} do
+      assert ConnHandler.visit(conn, "http://google.com/something")
     end
   end
 


### PR DESCRIPTION
Resolves #194 

What changed?
=============

Commit 668448ab introduced raising on paths that were not defined in the router.

That provides a nicer experience when TDDing, but people are using `assert_path` to assert they've landed on an external URL (think authentication failing or logging out of the app).

In those cases, the request is a 404. But since `assert_path` is just checking the `conn.request_path`, we're able to assert something about the path even if PhoenixTest cannot actually visit that external URL.

This commit adds a check to see if the path we're trying to validate with the router is internal or external.

- If external, we do not raise (since we might want to `assert_path`).
- If internal, we raise so that it's clear the path isn't defined in the application's router.

NOTE: to check if the request is external, we check the request's host against two hosts -- the endpoint's host and the [default `www.example.com` host] set in `Plug.Adapters.Test.Conn` (which gets used by `Phoenix.ConnTest.build_conn/0`). If either host matches, then the request is "internal".

[default host]: https://github.com/elixir-plug/plug/blob/1947edc8171f923ecc262efba6a0946264fa5582/lib/plug/adapters/test/conn.ex#L44