### PR TITLE
Fix: Find select nested in label

### DIFF
--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -528,7 +528,7 @@ defmodule PhoenixTest.Query do
         fn element -> Html.text(element) =~ text end
       end
 
-    Enum.filter(elements, filter_fun)
+    Enum.filter(elements, &(&1 |> Floki.filter_out("select") |> filter_fun.()))
   end
 
   defp filter_by_position(elements, opts) do

--- a/test/phoenix_test/element/select_test.exs
+++ b/test/phoenix_test/element/select_test.exs
@@ -19,6 +19,23 @@ defmodule PhoenixTest.Element.SelectTest do
       assert ["select_2"] = field.value
     end
 
+    test "finds select nested in label" do
+      html = """
+      <label>
+        Name
+        <select id="name" name="name">
+          <option value="select_1">Select 1</option>
+          <option value="select_2">Select 2</option>
+        </select>
+      </label>
+      """
+
+      field = Select.find_select_option!(html, "select", "Name", "Select 2", exact: true)
+
+      assert ~s|[id="name"]| = field.selector
+      assert ["select_2"] = field.value
+    end
+
     test "returns multiple selected option value" do
       html = """
       <label for="name">Name</label>


### PR DESCRIPTION
## Example
### Given
```html
      <label>
        Name
        <select id="name" name="name">
          <option value="select_1">Select 1</option>
          <option value="select_2">Select 2</option>
        </select>
      </label>
```

### when
```ex
|> select("Name", option: "Select 1")
```

### then
option is selected.

## Why does it currently fail?
The option text is included in `Floki.text` when searching for the label by text.
So an exact match fails, because `"Name" != "Name Select 1 Select 2"`.