### PR TITLE
Add tests for LV navigation in handle_info

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -982,6 +982,50 @@ defmodule PhoenixTest.LiveTest do
     end
   end
 
+  describe "live view navigation via handle_info" do
+    test "redirect with assert_path", %{conn: conn} do
+      conn
+      |> visit("/live/handle_info")
+      |> click_link("Redirect")
+      |> assert_path("/live/index")
+    end
+
+    test "redirect with unwrap", %{conn: conn} do
+      conn
+      |> visit("/live/handle_info")
+      |> click_link("Redirect")
+      |> unwrap(&Phoenix.LiveViewTest.assert_redirect(&1, "/live/index"))
+    end
+
+    test "redirect with tap", %{conn: conn} do
+      conn
+      |> visit("/live/handle_info")
+      |> click_link("Redirect")
+      |> tap(&Phoenix.LiveViewTest.assert_redirect(&1.view, "/live/index"))
+    end
+
+    test "patch with assert_path", %{conn: conn} do
+      conn
+      |> visit("/live/handle_info")
+      |> click_link("Patch")
+      |> assert_path("/live/info_handled")
+    end
+
+    test "patch with unwrap", %{conn: conn} do
+      conn
+      |> visit("/live/handle_info")
+      |> click_link("Patch")
+      |> unwrap(&Phoenix.LiveViewTest.assert_patch(&1, "/live/info_handled"))
+    end
+
+    test "patch with tap", %{conn: conn} do
+      conn
+      |> visit("/live/handle_info")
+      |> click_link("Patch")
+      |> tap(&Phoenix.LiveViewTest.assert_patch(&1.view, "/live/info_handled"))
+    end
+  end
+
   describe "open_browser" do
     setup do
       open_fun = fn view ->

--- a/test/support/web_app/handle_info_live.ex
+++ b/test/support/web_app/handle_info_live.ex
@@ -1,0 +1,33 @@
+defmodule PhoenixTest.WebApp.HandleInfoLive do
+  @moduledoc false
+  use Phoenix.LiveView
+
+  def render(assigns) do
+    ~H"""
+    <a phx-click="redirect-me">Redirect</a>
+    <a phx-click="patch-me">Patch</a>
+    """
+  end
+
+  def handle_params(_params, _uri, socket) do
+    {:noreply, socket}
+  end
+
+  def handle_event("redirect-me", _params, socket) do
+    send(self(), :redirect_me)
+    {:noreply, socket}
+  end
+
+  def handle_event("patch-me", _params, socket) do
+    send(self(), :patch_me)
+    {:noreply, socket}
+  end
+
+  def handle_info(:redirect_me, socket) do
+    {:noreply, push_navigate(socket, to: "/live/index")}
+  end
+
+  def handle_info(:patch_me, socket) do
+    {:noreply, push_patch(socket, to: "/live/info_handled")}
+  end
+end

--- a/test/support/web_app/router.ex
+++ b/test/support/web_app/router.ex
@@ -41,6 +41,8 @@ defmodule PhoenixTest.WebApp.Router do
       live "/live/async_page", AsyncPageLive
       live "/live/async_page_2", AsyncPage2Live
       live "/live/ordinal_inputs", OrdinalInputsLive
+      live "/live/handle_info", HandleInfoLive, :to_handle
+      live "/live/info_handled", HandleInfoLive, :handled
     end
 
     scope "/auth" do


### PR DESCRIPTION
I haven't dug too deep into #209 but I wanted to contribute some failing tests to exhibit the behaviour. I hope this helps clarify the issue. Or am I holding `phoenix_test` wrong?

It might also be worth adding that an equivalent LV test works:
```elixir
test "click link", %{conn: conn} do
  {:ok, view, _} = live(conn, "/live/handle_info")

  view
  |> element("a", "Redirect")
  |> render_click()

  assert_redirect(view, "/live/index")
end
```