### PR TITLE
return empty value for button if name is present and no value is found

### DIFF
--- a/lib/phoenix_test/element/button.ex
+++ b/lib/phoenix_test/element/button.ex
@@ -30,7 +30,7 @@ defmodule PhoenixTest.Element.Button do
     button_html = Html.raw(parsed)
     id = Html.attribute(parsed, "id")
     name = Html.attribute(parsed, "name")
-    value = Html.attribute(parsed, "value")
+    value = Html.attribute(parsed, "value") || if name, do: ""
     selector = Element.build_selector(parsed)
     text = Html.text(parsed)
     form_id = Html.attribute(parsed, "form")

--- a/test/phoenix_test/element/button_test.exs
+++ b/test/phoenix_test/element/button_test.exs
@@ -149,6 +149,19 @@ defmodule PhoenixTest.Element.ButtonTest do
       assert is_nil(button.name)
       assert is_nil(button.value)
     end
+
+    test "returns empty value if name is present and no value is found" do
+      html = """
+      <button name="generate">
+        Save
+      </button>
+      """
+
+      button = Button.find!(html, "button", "Save")
+
+      assert button.name == "generate"
+      assert button.value == ""
+    end
   end
 
   describe "belongs_to_form?" do


### PR DESCRIPTION
Issue: https://github.com/germsvel/phoenix_test/issues/219

If a button has a `name` attribute, but no `value`, the value is set to an an empty string, to mimic the browser behavior.

Before a button like this:

```elixir
<.button name="generate">
  Generate
</.button>
```
would not send the params `%{"generate" => ""}`