### PR TITLE
Pass the original filter text from `click_button/2` when calling `click_button/3`

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -70,7 +70,7 @@ defmodule PhoenixTest.Live do
       |> Query.find_by_role!(locator)
       |> Button.build(html)
 
-    click_button(session, button.selector, button.text)
+    click_button(session, button.selector, text)
   end
 
   def click_button(session, selector, text) do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -280,6 +280,12 @@ defmodule PhoenixTest.LiveTest do
         end)
       end
     end
+
+    test "does not raise when clicking a button that contains text wrapped in another element", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_button("An ID-less Span Wrapped")
+    end
   end
 
   describe "within/3" do

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -541,6 +541,11 @@ defmodule PhoenixTest.WebApp.IndexLive do
       <label for={@uploads.redirect_avatar.ref}>Redirect Avatar</label>
       <.live_file_input upload={@uploads.redirect_avatar} />
     </form>
+
+    <button phx-click="change-h3" phx-no-format>
+      An ID-less Span Wrapped
+      <span>Button</span>
+    </button>
     """
   end
 


### PR DESCRIPTION
This prevents `element/3` from failing to find the button when it has whitespace and newlines between part of the text an an element inside of the button.

Fixes #221