### PR TITLE
Fix: Repeated select/3 calls for multi select

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -465,8 +465,16 @@ defmodule PhoenixTest.LiveTest do
     test "works for multiple select", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> select("Race", option: "Elf")
       |> select("Race 2", option: ["Elf", "Dwarf"])
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "[elf, dwarf]")
+    end
+
+    test "works for multiple select with repeated calls", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> select("Race 2", option: "Elf")
+      |> select("Race 2", option: "Elf")
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "[elf, dwarf]")
     end


### PR DESCRIPTION
Calling `select/3` multiple times shouldn't fail.

For multi selects, it currently fails.

I've only created a failing test case for now.