### PR TITLE
Fix: check/3 in group loses initial checked

### DIFF
--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -544,6 +544,14 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "admin: on")
     end
 
+    test "preserves initially checked box in group", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> check("Checkbox group 2")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "checkbox_group: [1, 2]")
+    end
+
     test "handle checkbox name with '?'", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -173,6 +173,12 @@ defmodule PhoenixTest.WebApp.IndexLive do
         <option value="orc">Orc</option>
       </select>
 
+      <label>
+        <input type="checkbox" name="checkbox_group[]" value="1" checked />
+        Checkbox group 1 (initially checked)
+      </label>
+      <label><input type="checkbox" name="checkbox_group[]" value="2" /> Checkbox group 2</label>
+
       <fieldset>
         <legend>Please select your preferred contact method:</legend>
         <div>


### PR DESCRIPTION
Regression in phoenix_test 0.7

Only created a failing test case for now.