### PR TITLE
`assert_path` handles nested query params

### DIFF
--- a/lib/phoenix_test/utils.ex
+++ b/lib/phoenix_test/utils.ex
@@ -6,6 +6,9 @@ defmodule PhoenixTest.Utils do
 
   def stringify_keys_and_values(map) when is_map(map) do
     Map.new(map, fn
+      {k, v} when is_map(v) ->
+        {to_string(k), stringify_keys_and_values(v)}
+
       {k, v} when is_list(v) ->
         {to_string(k), Enum.map(v, &to_string/1)}
 

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -722,6 +722,12 @@ defmodule PhoenixTest.AssertionsTest do
       assert_path(session, "/page/index", query_params: %{"users" => ["frodo", "sam"]})
     end
 
+    test "handles query params that have a map as a value" do
+      session = %Live{current_path: "/page/index?filter[name]=frodo&filter[height]=1.24m"}
+
+      assert_path(session, "/page/index", query_params: %{"filter" => %{"name" => "frodo", "height" => "1.24m"}})
+    end
+
     test "handles asserting empty query params" do
       session = %Live{current_path: "/page/index"}
 

--- a/test/phoenix_test/utils_test.exs
+++ b/test/phoenix_test/utils_test.exs
@@ -27,5 +27,13 @@ defmodule PhoenixTest.UtilsTest do
 
       assert %{"greet" => ["hello", "hola"]} = result
     end
+
+    test "preserves nested map values" do
+      original = %{foo: %{bar: "baz"}}
+
+      result = Utils.stringify_keys_and_values(original)
+
+      assert %{"foo" => %{"bar" => "baz"}} = result
+    end
   end
 end


### PR DESCRIPTION
Similarly to https://github.com/germsvel/phoenix_test/issues/168, `assert_path/3` should be able to handle nested query params, given that [`Plug.Conn.Query` can generate it](https://hexdocs.pm/plug/1.18.0/Plug.Conn.Query.html#:~:text=Nested%20structures%20can%20be%20created%20via%20%5Bkey%5D%3A): 

```elixir
iex> Plug.Conn.Query.decode("foo[bar]=baz")
%{"foo" => %{"bar" => "baz"}}
```