### PR TITLE
Fix phx-trigger-action handling for dynamically rendered forms

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -475,7 +475,7 @@ defmodule PhoenixTest.Live do
         active_form? = form.selector == active_form.selector
         form_data = FormData.merge(form.form_data, if(active_form?, do: active_form.form_data, else: FormData.new()))
 
-        session.conn
+        %{session.conn | resp_body: html}
         |> PhoenixTest.Static.build()
         |> PhoenixTest.Static.submit_form(form.selector, form_data)
 

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -1165,6 +1165,15 @@ defmodule PhoenixTest.LiveTest do
       end
     end
 
+    test "handles phx-trigger-action on dynamically rendered forms", %{conn: conn} do
+      conn
+      |> visit("/live/dynamic_form")
+      |> click_button("Show Form")
+      |> fill_in("Message", with: "test")
+      |> submit()
+      |> assert_has("#form-data", text: "message: test")
+    end
+
     test "raises an error if field doesn't have a `name` attribute", %{conn: conn} do
       assert_raise ArgumentError, ~r/Field is missing a `name` attribute/, fn ->
         conn

--- a/test/support/web_app/dynamic_form_live.ex
+++ b/test/support/web_app/dynamic_form_live.ex
@@ -1,0 +1,37 @@
+defmodule PhoenixTest.WebApp.DynamicFormLive do
+  @moduledoc false
+
+  use Phoenix.LiveView
+
+  def render(assigns) do
+    ~H"""
+    <h1>Dynamic Form Test</h1>
+    <button phx-click="show-form">Show Form</button>
+
+    <form
+      :if={@show_form}
+      id="dynamic-form"
+      phx-submit="submit-form"
+      phx-trigger-action={@trigger_submit}
+      action="/page/create_record"
+      method="post"
+    >
+      <label for="message">Message</label>
+      <input id="message" name="message" />
+      <button type="submit">Submit</button>
+    </form>
+    """
+  end
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, show_form: false, trigger_submit: false)}
+  end
+
+  def handle_event("show-form", _, socket) do
+    {:noreply, assign(socket, :show_form, true)}
+  end
+
+  def handle_event("submit-form", _params, socket) do
+    {:noreply, assign(socket, :trigger_submit, true)}
+  end
+end

--- a/test/support/web_app/router.ex
+++ b/test/support/web_app/router.ex
@@ -40,6 +40,7 @@ defmodule PhoenixTest.WebApp.Router do
       live "/live/page_2", Page2Live
       live "/live/async_page", AsyncPageLive
       live "/live/async_page_2", AsyncPage2Live
+      live "/live/dynamic_form", DynamicFormLive
     end
 
     scope "/auth" do


### PR DESCRIPTION
**Problem:**
PhoenixTest failed to handle forms with `phx-trigger-action` that are rendered dynamically after LiveView events (not present in initial dead render). This resulted in "Could not find element with selector" errors during form submission.

**Root Cause:**
The `maybe_redirect/2` function in `PhoenixTest.Live` was using `session.conn.resp_body` (stale HTML from initial page load) when switching to Static context to handle `phx-trigger-action` forms. Dynamically rendered forms only exist in the current LiveView HTML, not in the original response body.

**Solution:**
Update `maybe_redirect/2` to use the current LiveView HTML as the `resp_body` when creating the Static session. This ensures `PhoenixTest.Static.submit_form/3` can find dynamically rendered forms.

Changes:
- `session.conn` → `%{session.conn | resp_body: html}`

**Test Case Added:**
- New `DynamicFormLive` that renders a form only after button click
- Test case: "handles phx-trigger-action on dynamically rendered forms"
- Validates the fix and prevents regressions

Fixes the core issue where PhoenixTest looked for forms in wrong HTML context.