### PR TITLE
support phx-value and JS command values with uncheck

### DIFF
--- a/lib/phoenix_test/element/field.ex
+++ b/lib/phoenix_test/element/field.ex
@@ -70,6 +70,8 @@ defmodule PhoenixTest.Element.Field do
 
   def phx_click?(field), do: LiveViewBindings.phx_click?(field.parsed)
 
+  def phx_value?(field), do: LiveViewBindings.phx_value?(field.parsed)
+
   def belongs_to_form?(field) do
     case Query.find_ancestor(field.source_raw, "form", field.selector) do
       {:found, _} -> true

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -189,6 +189,14 @@ defmodule PhoenixTest.Live do
     field = Field.find_checkbox!(html, input_selector, label, opts)
 
     cond do
+      # Support phx-click on checkboxes that have phx-value-key attributes too
+      Field.phx_click?(field) and Field.phx_value?(field) ->
+        session.view
+        |> element(field.selector)
+        |> render_click()
+        |> maybe_redirect(session)
+
+      # Support phx-click on checkboxes that aren't in forms
       Field.phx_click?(field) ->
         event = Html.attribute(field.parsed, "phx-click")
 

--- a/lib/phoenix_test/live_view_bindings.ex
+++ b/lib/phoenix_test/live_view_bindings.ex
@@ -10,8 +10,12 @@ defmodule PhoenixTest.LiveViewBindings do
     |> valid_event_or_js_command?()
   end
 
-  def phx_value?({_element, attributes, _children}) do
-    Enum.any?(attributes, fn {key, _value} -> String.starts_with?(key, "phx-value-") end)
+  def phx_value?(parsed_element) do
+    cond do
+      any_phx_value_attributes?(parsed_element) -> true
+      phx_click_command_has_value?(parsed_element) -> true
+      true -> false
+    end
   end
 
   defp valid_event_or_js_command?("[" <> _ = js_command) do
@@ -30,4 +34,26 @@ defmodule PhoenixTest.LiveViewBindings do
   defp valid_js_command?(["patch", _opts]), do: true
   defp valid_js_command?(["push", _opts]), do: true
   defp valid_js_command?([_command, _opts]), do: false
+
+  defp any_phx_value_attributes?({_element, attributes, _children}) when is_list(attributes) do
+    Enum.any?(attributes, fn {key, _value} -> String.starts_with?(key, "phx-value-") end)
+  end
+
+  defp phx_click_command_has_value?(parsed_element) when is_tuple(parsed_element) do
+    parsed_element
+    |> Html.attribute("phx-click")
+    |> phx_click_command_has_value?()
+  end
+
+  defp phx_click_command_has_value?("[" <> _ = js_command) do
+    js_command
+    |> Jason.decode!()
+    |> Enum.find(&match?(["push", _opts], &1))
+    |> case do
+      ["push", opts] -> Map.has_key?(opts, "value")
+      _ -> false
+    end
+  end
+
+  defp phx_click_command_has_value?(_), do: false
 end

--- a/lib/phoenix_test/live_view_bindings.ex
+++ b/lib/phoenix_test/live_view_bindings.ex
@@ -10,6 +10,10 @@ defmodule PhoenixTest.LiveViewBindings do
     |> valid_event_or_js_command?()
   end
 
+  def phx_value?({_element, attributes, _children}) do
+    Enum.any?(attributes, fn {key, _value} -> String.starts_with?(key, "phx-value-") end)
+  end
+
   defp valid_event_or_js_command?("[" <> _ = js_command) do
     js_command
     |> Jason.decode!()

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -677,6 +677,19 @@ defmodule PhoenixTest.LiveTest do
       |> refute_has("#checkbox-phx-click-values-abc[checked=checked]")
       |> assert_has("#checkbox-phx-click-values-abc-value", text: "Unchecked")
     end
+
+    test "sends phx-click JS command value when attribute used", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> refute_has("#checkbox-phx-click-values-def[checked=checked]")
+      |> assert_has("#checkbox-phx-click-values-def-value", text: "Unchecked")
+      |> check("Checkbox def")
+      |> assert_has("#checkbox-phx-click-values-def[checked=checked]")
+      |> assert_has("#checkbox-phx-click-values-def-value", text: "Checked")
+      |> uncheck("Checkbox def")
+      |> refute_has("#checkbox-phx-click-values-def[checked=checked]")
+      |> assert_has("#checkbox-phx-click-values-def-value", text: "Unchecked")
+    end
   end
 
   describe "choose/3" do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -664,6 +664,19 @@ defmodule PhoenixTest.LiveTest do
         uncheck(session, "Invalid Checkbox")
       end
     end
+
+    test "sends phx-value when phx-click attribute used", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> refute_has("#checkbox-phx-click-values-abc[checked=checked]")
+      |> assert_has("#checkbox-phx-click-values-abc-value", text: "Unchecked")
+      |> check("Checkbox abc")
+      |> assert_has("#checkbox-phx-click-values-abc[checked=checked]")
+      |> assert_has("#checkbox-phx-click-values-abc-value", text: "Checked")
+      |> uncheck("Checkbox abc")
+      |> refute_has("#checkbox-phx-click-values-abc[checked=checked]")
+      |> assert_has("#checkbox-phx-click-values-abc-value", text: "Unchecked")
+    end
   end
 
   describe "choose/3" do

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -546,6 +546,22 @@ defmodule PhoenixTest.WebApp.IndexLive do
       An ID-less Span Wrapped
       <span>Button</span>
     </button>
+
+    <div>
+      <div :for={{id, checked?} <- @checked_keys}>
+        <label for={"checkbox-phx-click-values-#{id}"}>Checkbox {id}</label>
+        <input
+          type="checkbox"
+          id={"checkbox-phx-click-values-#{id}"}
+          phx-click="toggle-checkbox-phx-value"
+          phx-value-id={id}
+          checked={checked?}
+        />
+        <span id={"checkbox-phx-click-values-#{id}-value"}>
+          {if(checked?, do: "Checked", else: "Unchecked")}
+        </span>
+      </div>
+    </div>
     """
   end
 
@@ -569,6 +585,7 @@ defmodule PhoenixTest.WebApp.IndexLive do
       |> assign(:show_form_errors, false)
       |> assign(:cities, [])
       |> assign(:hidden_input_race, "human")
+      |> assign(:checked_keys, %{"abc" => false})
       |> assign(:trigger_submit, false)
       |> assign(:trigger_multiple_submit, false)
       |> assign(:redirect_and_trigger_submit, false)
@@ -799,6 +816,12 @@ defmodule PhoenixTest.WebApp.IndexLive do
       :noreply,
       assign(socket, :upload_change_triggered, true)
     }
+  end
+
+  def handle_event("toggle-checkbox-phx-value", %{"id" => id}, socket) do
+    checked_keys = Map.update(socket.assigns.checked_keys, id, true, &(not &1))
+
+    {:noreply, assign(socket, :checked_keys, checked_keys)}
   end
 
   defp render_input_data(key, value) when value == "" or is_nil(value) do

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -548,19 +548,30 @@ defmodule PhoenixTest.WebApp.IndexLive do
     </button>
 
     <div>
-      <div :for={{id, checked?} <- @checked_keys}>
-        <label for={"checkbox-phx-click-values-#{id}"}>Checkbox {id}</label>
-        <input
-          type="checkbox"
-          id={"checkbox-phx-click-values-#{id}"}
-          phx-click="toggle-checkbox-phx-value"
-          phx-value-id={id}
-          checked={checked?}
-        />
-        <span id={"checkbox-phx-click-values-#{id}-value"}>
-          {if(checked?, do: "Checked", else: "Unchecked")}
-        </span>
-      </div>
+      <label for={"checkbox-phx-click-values-abc"}>Checkbox abc</label>
+      <input
+        type="checkbox"
+        id="checkbox-phx-click-values-abc"
+        phx-click="toggle-checkbox-phx-value"
+        phx-value-id="abc"
+        checked={@checked_keys["abc"]}
+      />
+      <span id={"checkbox-phx-click-values-abc-value"}>
+        {if(@checked_keys["abc"], do: "Checked", else: "Unchecked")}
+      </span>
+    </div>
+
+    <div>
+      <label for={"checkbox-phx-click-values-def"}>Checkbox def</label>
+      <input
+        type="checkbox"
+        id="checkbox-phx-click-values-def"
+        phx-click={Phoenix.LiveView.JS.push("toggle-checkbox-phx-value", value: %{id: "def"})}
+        checked={@checked_keys["def"]}
+      />
+      <span id={"checkbox-phx-click-values-def-value"}>
+        {if(@checked_keys["def"], do: "Checked", else: "Unchecked")}
+      </span>
     </div>
     """
   end
@@ -585,7 +596,7 @@ defmodule PhoenixTest.WebApp.IndexLive do
       |> assign(:show_form_errors, false)
       |> assign(:cities, [])
       |> assign(:hidden_input_race, "human")
-      |> assign(:checked_keys, %{"abc" => false})
+      |> assign(:checked_keys, %{"abc" => false, "def" => false})
       |> assign(:trigger_submit, false)
       |> assign(:trigger_multiple_submit, false)
       |> assign(:redirect_and_trigger_submit, false)

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -548,7 +548,7 @@ defmodule PhoenixTest.WebApp.IndexLive do
     </button>
 
     <div>
-      <label for={"checkbox-phx-click-values-abc"}>Checkbox abc</label>
+      <label for="checkbox-phx-click-values-abc">Checkbox abc</label>
       <input
         type="checkbox"
         id="checkbox-phx-click-values-abc"
@@ -556,20 +556,20 @@ defmodule PhoenixTest.WebApp.IndexLive do
         phx-value-id="abc"
         checked={@checked_keys["abc"]}
       />
-      <span id={"checkbox-phx-click-values-abc-value"}>
+      <span id="checkbox-phx-click-values-abc-value">
         {if(@checked_keys["abc"], do: "Checked", else: "Unchecked")}
       </span>
     </div>
 
     <div>
-      <label for={"checkbox-phx-click-values-def"}>Checkbox def</label>
+      <label for="checkbox-phx-click-values-def">Checkbox def</label>
       <input
         type="checkbox"
         id="checkbox-phx-click-values-def"
         phx-click={Phoenix.LiveView.JS.push("toggle-checkbox-phx-value", value: %{id: "def"})}
         checked={@checked_keys["def"]}
       />
-      <span id={"checkbox-phx-click-values-def-value"}>
+      <span id="checkbox-phx-click-values-def-value">
         {if(@checked_keys["def"], do: "Checked", else: "Unchecked")}
       </span>
     </div>


### PR DESCRIPTION
Closes: https://github.com/germsvel/phoenix_test/issues/237

Sorry of the delay, had to work through submission approval.

This PR updates `uncheck/3|4` to check if the checkbox has a `phx-click` attribute and either also has `phx-value` attributes or the `phx-click` attribute is a JS command with a value assigned, and makes sure those values are passed as params to the `handle_action/3` callback.

If there is a `phx-click` attribute but no identifiable values, the previous behavior of using an empty map for params is maintained for compatibility.