### PR TITLE
Preserve order of appearance for array inputs

### DIFF
--- a/lib/phoenix_test/form_data.ex
+++ b/lib/phoenix_test/form_data.ex
@@ -40,7 +40,7 @@ defmodule PhoenixTest.FormData do
           if value in existing_value do
             existing_value
           else
-            [value | existing_value]
+            existing_value ++ List.wrap(value)
           end
         end)
 

--- a/test/phoenix_test/form_payload_test.exs
+++ b/test/phoenix_test/form_payload_test.exs
@@ -56,7 +56,7 @@ defmodule PhoenixTest.FormPayloadTest do
              } = FormPayload.new(form.form_data)
     end
 
-    test "multiple checkbox values named with [] resolve to a list" do
+    test "multiple checkbox values named with [] resolve to a list in order of their appearance" do
       html = """
       <form id="form">
         <input name="checkbox[]" type="checkbox" value="some_value" checked />
@@ -66,7 +66,7 @@ defmodule PhoenixTest.FormPayloadTest do
 
       form = Form.find!(html, "form")
 
-      assert %{"checkbox" => ["another_value", "some_value"]} = FormPayload.new(form.form_data)
+      assert %{"checkbox" => ["some_value", "another_value"]} = FormPayload.new(form.form_data)
     end
 
     test "single checkboxe value named with [] resolves to a list" do
@@ -82,7 +82,7 @@ defmodule PhoenixTest.FormPayloadTest do
       assert %{"checkbox" => ["some_value"]} = FormPayload.new(form.form_data)
     end
 
-    test "multiple hidden inputs named with [] resolve to a list" do
+    test "multiple hidden inputs named with [] resolve to a list in order of their appearance" do
       html = """
       <form id="form">
         <input name="hidden[]" type="hidden" value="some_value" />
@@ -92,7 +92,7 @@ defmodule PhoenixTest.FormPayloadTest do
 
       form = Form.find!(html, "form")
 
-      assert %{"hidden" => ["another_value", "some_value"]} = FormPayload.new(form.form_data)
+      assert %{"hidden" => ["some_value", "another_value"]} = FormPayload.new(form.form_data)
     end
 
     test "single hidden input value named with [] resolves to a list" do


### PR DESCRIPTION
Elements in lists/arrays in forms (referenced by unindexed `field_name[]`) have been aggregated in the order they appear in the HTML document before the refactoring in https://github.com/germsvel/phoenix_test/commit/b1400b3faee35f9e5f078422042b309895c00e51
Since then, the order has been the opposite.
This works in most cases, but sometimes the order is significant and flipping it can become problematic.

This PR reverts the order to the "natural" order of occurrence in the document.
