### PR TITLE
Fix: allow multiple select and checkboxes

### DIFF
--- a/lib/phoenix_test/form_data.ex
+++ b/lib/phoenix_test/form_data.ex
@@ -34,7 +34,7 @@ defmodule PhoenixTest.FormData do
   def add_data(%__MODULE__{} = form_data, name, value) when is_nil(name) or is_nil(value), do: form_data
 
   def add_data(%__MODULE__{} = form_data, name, value) do
-    if String.ends_with?(name, "[]") do
+    if allows_multiple_values?(name) do
       new_data =
         Map.update(form_data.data, name, List.wrap(value), fn existing_value ->
           if value in existing_value do
@@ -51,8 +51,19 @@ defmodule PhoenixTest.FormData do
   end
 
   def merge(%__MODULE__{data: data1}, %__MODULE__{data: data2}) do
-    %__MODULE__{data: Map.merge(data1, data2)}
+    data =
+      Map.merge(data1, data2, fn k, v1, v2 ->
+        if allows_multiple_values?(k) do
+          Enum.uniq(v1 ++ v2)
+        else
+          v2
+        end
+      end)
+
+    %__MODULE__{data: data}
   end
+
+  defp allows_multiple_values?(field_name), do: String.ends_with?(field_name, "[]")
 
   def filter(%__MODULE__{data: data}, fun) do
     data =
@@ -69,7 +80,8 @@ defmodule PhoenixTest.FormData do
 
   def has_data?(%__MODULE__{data: data}, name, value) do
     field_data = Map.get(data, name, [])
-    value == field_data or value in field_data
+
+    value == field_data or value in List.wrap(field_data)
   end
 
   def to_list(%__MODULE__{data: data}) do

--- a/test/phoenix_test/form_data_test.exs
+++ b/test/phoenix_test/form_data_test.exs
@@ -148,6 +148,32 @@ defmodule PhoenixTest.FormDataTest do
       assert FormData.has_data?(form_data, "name", "frodo")
       assert FormData.has_data?(form_data, "email", "frodo@fellowship.com")
     end
+
+    test "when a key ends in [], values are combined" do
+      fd1 =
+        FormData.add_data(FormData.new(), "contact[]", "email")
+
+      fd2 =
+        FormData.add_data(FormData.new(), "contact[]", "sms")
+
+      form_data = FormData.merge(fd1, fd2)
+
+      assert FormData.has_data?(form_data, "contact[]", "email")
+      assert FormData.has_data?(form_data, "contact[]", "sms")
+    end
+
+    test "when a key doesn't end in [], new value overrides original value" do
+      fd1 =
+        FormData.add_data(FormData.new(), "contact", "email")
+
+      fd2 =
+        FormData.add_data(FormData.new(), "contact", "sms")
+
+      form_data = FormData.merge(fd1, fd2)
+
+      refute FormData.has_data?(form_data, "contact", "email")
+      assert FormData.has_data?(form_data, "contact", "sms")
+    end
   end
 
   describe "filter" do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -481,6 +481,15 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "[elf, dwarf]")
     end
 
+    test "works for multiple select with repeated calls", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> select("Race 2", option: "Elf")
+      |> select("Race 2", option: "Dwarf")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "[elf, dwarf]")
+    end
+
     test "works with phx-click outside of forms", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -552,6 +561,14 @@ defmodule PhoenixTest.LiveTest do
       |> check("Admin")
       |> click_button("Save Full Form")
       |> assert_has("#form-data", text: "admin: on")
+    end
+
+    test "preserves initially checked box in group", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> check("Checkbox group 2")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "checkbox_group: [1, 2]")
     end
 
     test "handle checkbox name with '?'", %{conn: conn} do

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -173,6 +173,12 @@ defmodule PhoenixTest.WebApp.IndexLive do
         <option value="orc">Orc</option>
       </select>
 
+      <label>
+        <input type="checkbox" name="checkbox_group[]" value="1" checked />
+        Checkbox group 1 (initially checked)
+      </label>
+      <label><input type="checkbox" name="checkbox_group[]" value="2" /> Checkbox group 2</label>
+
       <fieldset>
         <legend>Please select your preferred contact method:</legend>
         <div>


### PR DESCRIPTION
Supersedes #224, #225, 
Closes #239 

What changed?
=============

When we refactored `FormData`, we lost the ability to have multiple selects and multiple checkboxes in some scenarios.

For example:

- when we have a default checkbox "checked" and add a new one
- when we use `select` multiple times in a row

This commit improves the merging behaviour of two FormData structs so that we can handle key names that allow for multi-selects (i.e. they end in `[]`)

Thanks to @ftes for providing test cases for these failures.