### PR TITLE
Fix #227

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -82,6 +82,8 @@ defmodule PhoenixTest.Live do
   end
 
   defp handle_click_button(session, button) do
+    button = %{button | selector: PhoenixTest.SessionHelpers.scope_selector(session.within, button.selector)}
+
     cond do
       Button.phx_click?(button) ->
         session.view

--- a/lib/phoenix_test/session_helpers.ex
+++ b/lib/phoenix_test/session_helpers.ex
@@ -2,11 +2,14 @@ defmodule PhoenixTest.SessionHelpers do
   @moduledoc false
   def within(session, selector, fun) when is_binary(selector) and is_function(fun, 1) do
     session
-    |> Map.update!(:within, fn
-      :none -> selector
-      parent when is_binary(parent) -> parent <> " " <> selector
-    end)
+    |> Map.update!(:within, &scope_selector(&1, selector))
     |> fun.()
     |> Map.put(:within, :none)
+  end
+
+  def scope_selector(:none, selector), do: selector
+
+  def scope_selector(within, selector) when is_binary(within) do
+    within <> " " <> selector
   end
 end

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -135,10 +135,10 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#tab", text: "Tab title")
     end
 
-    test "bug", %{conn: conn} do
+    test "selector inside within only finds contained elements", %{conn: conn} do
       conn
       |> visit("/live/index")
-      |> within("div:lexbor-contains('wibble')", fn session ->
+      |> within(".wibble", fn session ->
         # Should only find a single button, but finds 2
         click_button(session, "button", "action")
       end)

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -135,6 +135,15 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#tab", text: "Tab title")
     end
 
+    test "bug", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("div:lexbor-contains('wibble')", fn session ->
+        # Should only find a single button, but finds 2
+        click_button(session, "button", "action")
+      end)
+    end
+
     test "handles a `phx-click` button", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -3,6 +3,8 @@ defmodule PhoenixTest.WebApp.IndexLive do
 
   use Phoenix.LiveView
 
+  alias Phoenix.LiveView.JS
+
   def render(assigns) do
     ~H"""
     <h1 id="title" class="title" data-role="title">LiveView main page</h1>
@@ -19,6 +21,15 @@ defmodule PhoenixTest.WebApp.IndexLive do
     <h2 :if={@details}>LiveView main page details</h2>
 
     <h3>{@h3}</h3>
+
+    <div>
+      <div>
+        wibble <button phx-click={JS.push("wibble")}>action</button>
+      </div>
+      <div>
+        wobble <button phx-click={JS.push("wobble")}>action</button>
+      </div>
+    </div>
 
     <button phx-click="change-h3">Change h3</button>
 

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -3,8 +3,6 @@ defmodule PhoenixTest.WebApp.IndexLive do
 
   use Phoenix.LiveView
 
-  alias Phoenix.LiveView.JS
-
   def render(assigns) do
     ~H"""
     <h1 id="title" class="title" data-role="title">LiveView main page</h1>
@@ -23,11 +21,11 @@ defmodule PhoenixTest.WebApp.IndexLive do
     <h3>{@h3}</h3>
 
     <div>
-      <div>
-        wibble <button phx-click={JS.push("wibble")}>action</button>
+      <div class="wibble">
+        <button phx-click="do-it">action</button>
       </div>
-      <div>
-        wobble <button phx-click={JS.push("wobble")}>action</button>
+      <div class="wobble">
+        <button phx-click="do-it">action</button>
       </div>
     </div>
 
@@ -848,6 +846,10 @@ defmodule PhoenixTest.WebApp.IndexLive do
     checked_keys = Map.update(socket.assigns.checked_keys, id, true, &(not &1))
 
     {:noreply, assign(socket, :checked_keys, checked_keys)}
+  end
+
+  def handle_event("do-it", _, socket) do
+    {:noreply, socket}
   end
 
   defp render_input_data(key, value) when value == "" or is_nil(value) do


### PR DESCRIPTION
I took your test as a starting point and implemented a possible fix for https://github.com/germsvel/phoenix_test/issues/227

I made the minimal changes needed to fix this issue, however I think a proper fix would affect a lot more code.
Because of that I kept this PR in a draft state, as I don't want to do many invasive changes.

Essentially everywhere a struct like `Button` or e.g. `Field` is used, the constructed selector needs to respect the current `within`. So this bug is almost certainly also present outside of `click_button`.

Instead of what I did in my fix, a better approach would probably be to pass around the current session into `Button.find!` and similar such that the correct selector can be constructed then.