### PR TITLE
Fix: keep provided selector in `click_button/3`

### DIFF
--- a/lib/phoenix_test/element/button.ex
+++ b/lib/phoenix_test/element/button.ex
@@ -14,6 +14,17 @@ defmodule PhoenixTest.Element.Button do
     html
     |> Query.find!(selector, text)
     |> build(html)
+    |> keep_best_selector(selector)
+  end
+
+  defp keep_best_selector(button, provided_selector) do
+    case provided_selector do
+      "button" ->
+        button
+
+      anything_better_than_button ->
+        %{button | selector: anything_better_than_button}
+    end
   end
 
   def find_first(html) do

--- a/test/phoenix_test/element/button_test.exs
+++ b/test/phoenix_test/element/button_test.exs
@@ -57,6 +57,18 @@ defmodule PhoenixTest.Element.ButtonTest do
 
       assert button.selector == ~s(button[name="super"][value="button"])
     end
+
+    test "keeps provided selector if more complex than 'button'" do
+      html = """
+        <div id="button-id">
+          <button>Save</button>
+        </div>
+      """
+
+      button = Button.find!(html, "#button-id button", "Save")
+
+      assert button.selector == ~s(#button-id button)
+    end
   end
 
   describe "button.form_id" do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -127,7 +127,7 @@ defmodule PhoenixTest.LiveTest do
     end
   end
 
-  describe "click_button/2" do
+  describe "click_button" do
     test "finds button by substring", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -286,6 +286,12 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> visit("/live/index")
       |> click_button("An ID-less Span Wrapped")
+    end
+
+    test "does not raise when targetting duplicate button differentiated by wrapped ID", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_button("#button-with-id-1 button", "Duplicate button with wrapped id")
     end
   end
 

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -29,6 +29,13 @@ defmodule PhoenixTest.WebApp.IndexLive do
 
     <button phx-click="show-tab">Show tab</button>
 
+    <div id="button-with-id-1">
+      <button phx-click="show-tab">Duplicate button with wrapped id</button>
+    </div>
+    <div id="button-with-id-2">
+      <button phx-click="show-tab">Duplicate button with wrapped id</button>
+    </div>
+
     <div :if={@show_tab} id="tab">
       <h2>Tab title</h2>
     </div>


### PR DESCRIPTION
Resolves #252, #257

What changed?
=============

Whenever we pass a selector in `click_button/3`, we're correctly using the selector to find the button. But then we're incorrectly relying on the parsed button's data to generate a new selector.

That happens because we're no longer using the provided selectors. Instead, we use the parsed button's selector.

That's not typically a problem unless the selector provided had a descendant selector (meaning it was using data outside of the button itself). In those cases, subsequent attempts to use `button.selector` fail if there are duplicates on the page.

To fix that, we simply rely on the selector provided so long as it's something more complex than mere "button". If it's just "button", we know that the selector we can generate from the parsed data is equal or more specific. But if the user passes a selector, and we found a button with that selector, we should trust that selector the to be a good enough for the rest of the operations.