### PR TITLE
Improve `HTML.inner_text`. Rename `element_text`

### DIFF
--- a/lib/phoenix_test/element/button.ex
+++ b/lib/phoenix_test/element/button.ex
@@ -42,7 +42,7 @@ defmodule PhoenixTest.Element.Button do
     name = Html.attribute(parsed, "name")
     value = Html.attribute(parsed, "value") || if name, do: ""
     selector = Element.build_selector(parsed)
-    text = Html.inner_text(parsed)
+    text = Html.element_text(parsed)
     type = Html.attribute(parsed, "type") || "submit"
     form_id = Html.attribute(parsed, "form")
 

--- a/lib/phoenix_test/element/form.ex
+++ b/lib/phoenix_test/element/form.ex
@@ -166,7 +166,7 @@ defmodule PhoenixTest.Element.Form do
   end
 
   defp element_value(element) do
-    Html.attribute(element, "value") || Html.inner_text(element)
+    Html.attribute(element, "value") || Html.element_text(element)
   end
 
   defp operative_method(%LazyHTML{} = form) do

--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -530,9 +530,9 @@ defmodule PhoenixTest.Query do
 
     filter_fun =
       if exact_match do
-        &(Html.inner_text(&1) == text)
+        &(Html.element_text(&1) == text)
       else
-        &(Html.inner_text(&1) =~ text)
+        &(Html.element_text(&1) =~ text)
       end
 
     Enum.filter(elements, &(&1 |> LazyHTML.filter(":not(select)") |> filter_fun.()))

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -35,7 +35,7 @@ defmodule PhoenixTest.Static do
     |> render_html()
     |> Query.find("title")
     |> case do
-      {:found, element} -> Html.inner_text(element)
+      {:found, element} -> Html.element_text(element)
       _ -> nil
     end
   end

--- a/test/phoenix_test/html_test.exs
+++ b/test/phoenix_test/html_test.exs
@@ -3,41 +3,98 @@ defmodule PhoenixTest.HtmlTest do
 
   alias PhoenixTest.Html
 
-  describe "inner_text" do
+  describe "element_text" do
     test "extracts text from parsed html, removing extra whitespace" do
       html = """
-        <label>
-          hello
-         <em>world!</em>
-        </label>
+      <label>
+        hello
+        <em>world!</em>
+      </label>
       """
 
       result =
         html
         |> Html.parse_fragment()
-        |> Html.inner_text()
+        |> Html.element_text()
 
       assert result == "hello world!"
     end
 
-    test "extracts text but excludes select elements and their options" do
+    test "extracts the text from the top level element, but includes known text elements)" do
       html = """
-        <div>
-          <p>Choose an option:</p>
-          <select>
-            <option value="1">First option</option>
-            <option value="2">Second option</option>
-          </select>
-          <p>More text here</p>
-        </div>
+      <div>
+        hello
+        <a href="/">elixir</a>
+        <span>and</span>
+        <small>phoenix</small>
+        <em>world!</em>
+
+        <label>excluded text</label>
+        <form>also excluded</form>
+        <textarea>also excluded</textarea>
+      </div>
       """
 
       result =
         html
         |> Html.parse_fragment()
-        |> Html.inner_text()
+        |> Html.element_text()
+
+      assert result == "hello elixir and phoenix world!"
+    end
+
+    test "extracts text but excludes select elements and their options" do
+      html = """
+      <div>
+        <p>Choose an option:</p>
+        <select>
+          <option value="1">First option</option>
+          <option value="2">Second option</option>
+        </select>
+        <p>More text here</p>
+      </div>
+      """
+
+      result =
+        html
+        |> Html.parse_fragment()
+        |> Html.element_text()
 
       assert result == "Choose an option: More text here"
+    end
+
+    test "extracts text from label but excludes textarea value" do
+      html = """
+      <label for="wrapped-notes">
+        Wrapped notes
+
+        <textarea name="wrapped-notes" rows="5" cols="33">
+          Prefilled wrapped notes
+        </textarea>
+      </label>
+      """
+
+      result =
+        html
+        |> Html.parse_fragment()
+        |> Html.element_text()
+
+      assert result == "Wrapped notes"
+    end
+
+    test "includes textarea text if it's the top-level element" do
+      html = """
+      <textarea name="wrapped-notes" rows="5" cols="33">
+        Prefilled notes
+      </textarea>
+      """
+
+      result =
+        html
+        |> Html.parse_fragment()
+        |> Html.element_text()
+
+      assert result == "Prefilled notes"
     end
   end
 end

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -362,6 +362,14 @@ defmodule PhoenixTest.LiveTest do
       )
     end
 
+    test "can fill-in prefilled textareas where label wraps textarea", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> fill_in("Wrapped notes", with: "Some description")
+      |> click_button("Save Full Form")
+      |> assert_has("#form-data", text: "wrapped-notes: Some description")
+    end
+
     test "can fill-in complex form fields", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/phoenix_test/query_test.exs
+++ b/test/phoenix_test/query_test.exs
@@ -725,6 +725,20 @@ defmodule PhoenixTest.QueryTest do
 
       assert {"input", [{"id", "greeting"} | _], []} = Html.element(element)
     end
+
+    test "can filter labels wrapping a pre-filled textarea" do
+      html = """
+      <label for="wrapped-notes">
+        Wrapped notes <textarea name="wrapped-notes" rows="5" cols="33">
+          Prefilled wrapped notes
+        </textarea>
+      </label>
+      """
+
+      {:found, element} = Query.find_by_label(html, "label", "Wrapped notes")
+
+      assert {"label", [{"for", "wrapped-notes"}], _} = Html.element(element)
+    end
   end
 
   describe "find_ancestor!/3" do

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -206,8 +206,14 @@ defmodule PhoenixTest.WebApp.IndexLive do
 
       <label for="notes">Notes</label>
       <textarea id="notes" name="notes" rows="5" cols="33">
-      Prefilled notes
+        Prefilled notes
       </textarea>
+
+      <label for="wrapped-notes">
+        Wrapped notes <textarea name="wrapped-notes" rows="5" cols="33">
+          Prefilled wrapped notes
+        </textarea>
+      </label>
 
       <label for="disabled_textarea">Disabled textaread</label>
       <textarea id="disabled_textarea" name="disabled_textarea" rows="5" cols="33" disabled>


### PR DESCRIPTION
Closes https://github.com/germsvel/phoenix_test/issues/256

What changed?
==============

The purpose of `HTML.inner_text` was always to try to extract the text of an element without going too deeply into its children element. But to try to include those "extra" portions of text that might be in an `<em>` tag (or the like). 

For example, we probably want to be able to capture "hello world" out of `<div>hello <em>world</em></div>`, but we don't want to include text inside of a `<textarea>` when we're just trying to match on a label's text.

So, to handle all of that, we reverse the logic inside of `inner_text`: instead of excluding data for "select" (and add "textarea" to that list), we include additional text from children nodes when they are "known text nodes".

We define "known text nodes" as those listed in [MDN Element docs] in the [text content] or [inline text semantics] sections. And rename `Html.inner_text` to `Html.element_text` to try to capture the intent. 

[MDN Element docs]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements
[text content]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements#inline_text_semantics
[inline text semantics]: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements#inline_text_semantics