### PR TITLE
feat: Target nested LiveViews with `within/2`

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -421,10 +421,13 @@ defmodule PhoenixTest do
   defdelegate click_button(session, selector, text), to: Driver
 
   @doc """
-  Helpers to scope filling out form within a given selector. Use this if you
-  have more than one form on a page with similar labels.
+  Helper to scope filling out form within a given selector or targeting child
+  LiveViews.
 
   ## Examples
+
+  For example, you can use this if you have more than one form on a page with
+  similar labels.
 
   Given we have some HTML like this:
 
@@ -449,6 +452,24 @@ defmodule PhoenixTest do
     session
     |> fill_in("Name", with: "Aragorn")
     |> check("Admin")
+  end)
+  ```
+
+  ---
+
+  You can also use `within/2` to scope actions to a child LiveView (i.e.
+  something rendered via
+  [`live_render/3`](https://hexdocs.pm/phoenix_live_view/Phoenix.Component.html#live_render/3)).
+
+  NOTE: that child LiveViews can _only_ be targeted by ID, so make sure the
+  selector you pass to `within/2` is an ID.
+
+  ```elixir
+  session
+  |> within("#child-live-view", fn session ->
+    session
+    |> fill_in("Email", with: "someone@example.com")
+    |> click_button("Save") # <- event triggered will be sent to child LiveView
   end)
   ```
   """

--- a/lib/phoenix_test/live_view_bindings.ex
+++ b/lib/phoenix_test/live_view_bindings.ex
@@ -18,6 +18,12 @@ defmodule PhoenixTest.LiveViewBindings do
     end
   end
 
+  def phx_session?(parsed_element) do
+    parsed_element
+    |> Html.attribute("data-phx-session")
+    |> Utils.present?()
+  end
+
   defp valid_event_or_js_command?("[" <> _ = js_command) do
     js_command
     |> Jason.decode!()

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -324,6 +324,18 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("input", label: "Email", value: "someone@example.com")
     end
 
+    test "can target subsequent calls to nested liveview", %{conn: conn} do
+      conn
+      |> visit("/live/nested")
+      |> within("#child-live-view", fn session ->
+        session
+        |> fill_in("Email", with: "someone@example.com")
+        |> click_button("Save")
+        |> assert_has("#child-view-form-data", text: "email: someone@example.com")
+      end)
+      |> refute_has("#parent-view-form-data", text: "email: someone@example.com")
+    end
+
     test "raises when data is not in scoped HTML", %{conn: conn} do
       assert_raise ArgumentError, ~r/Could not find element with label "User Name"/, fn ->
         conn

--- a/test/support/web_app/nested_live.ex
+++ b/test/support/web_app/nested_live.ex
@@ -1,0 +1,54 @@
+defmodule PhoenixTest.WebApp.ChildLive do
+  @moduledoc false
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :form_data, %{})}
+  end
+
+  def render(assigns) do
+    ~H"""
+    <h1>Child LiveView</h1>
+
+    <form phx-submit="save-form">
+      <label>
+        Email <input type="email" name="email" />
+      </label>
+
+      <button type="submit">Save</button>
+    </form>
+
+    <div id="child-view-form-data">
+      <%= for {key, value} <- @form_data do %>
+        {key}: {value}
+      <% end %>
+    </div>
+    """
+  end
+
+  def handle_event("save-form", params, socket) do
+    {:noreply, assign(socket, :form_data, params)}
+  end
+end
+
+defmodule PhoenixTest.WebApp.NestedLive do
+  @moduledoc false
+
+  use Phoenix.LiveView
+
+  def mount(_params, _session, socket) do
+    {:ok, assign(socket, :form_data, %{})}
+  end
+
+  def render(assigns) do
+    ~H"""
+    {live_render(@socket, PhoenixTest.WebApp.ChildLive, id: "child-live-view")}
+
+    <div id="parent-view-form-data">
+      <%= for {key, value} <- @form_data do %>
+        {key}: {value}
+      <% end %>
+    </div>
+    """
+  end
+end

--- a/test/support/web_app/router.ex
+++ b/test/support/web_app/router.ex
@@ -42,6 +42,7 @@ defmodule PhoenixTest.WebApp.Router do
       live "/live/async_page_2", AsyncPage2Live
       live "/live/dynamic_form", DynamicFormLive
       live "/live/simple_ordinal_inputs", SimpleOrdinalInputsLive
+      live "/live/nested", NestedLive
     end
 
     scope "/auth" do


### PR DESCRIPTION
Closes #264 

What changed?
=============

We allow targeting of nested LiveViews with `within/2`. Under the hood, that will check if the HTML node the CSS selector is targeting is a LiveView (we check by proxy by checking if it has a `data-phx-session` attribute).

If it is a nested LiveView, we use LiveViewTest's `find_child_live` to scope the operations inside `within/2` to that new view.

Why do we need that?
--------------------

Without finding the nested LiveView, we can interact with forms, buttons, etc. but any event that gets trigered gets sent (incorrectly) to the parent LiveView.