### PR TITLE
Add failing tests: whitespace no longer ignored in assert_has

### DIFF
--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -118,6 +118,18 @@ defmodule PhoenixTest.AssertionsTest do
       |> assert_has("[data-phx-main]", text: "Country")
     end
 
+    test "succeeds on text assertion, ignores newline", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> assert_has("#with-newline", text: "With newline")
+    end
+
+    test "succeeds on text assertion, ignores <br/>", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> assert_has("#with-br", text: "With br")
+    end
+
     test "raises an error if value cannot be found", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -11,6 +11,12 @@ defmodule PhoenixTest.LiveTest do
     %{conn: Phoenix.ConnTest.build_conn()}
   end
 
+  test "ignores <br/>", %{conn: conn} do
+    conn
+    |> visit("/live/index")
+    |> assert_has("#with-br", text: "With br")
+  end
+
   describe "render_page_title/1" do
     test "renders the default page title", %{conn: conn} do
       title =

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -93,6 +93,15 @@ defmodule PhoenixTest.WebApp.IndexLive do
       </label>
     </form>
 
+    <div id="with-newline">
+      With
+      newline
+    </div>
+
+    <div id="with-br">
+      With <br /> br
+    </div>
+
     <form id="country-form" phx-change="select-country">
       <label for="country">Country</label>
       <select id="country" name="country">


### PR DESCRIPTION
phoenix_test 0.8.3 ignored `<br/>` line breaks when asserting on text using `assert_has(selector, text: ...)`.
phoenix_test 0.9.0 no longer ignores `<br/>`.

This was undocumented behaviour. I personally found the old behaviour helpful.