### PR TITLE
ensure `find_one_of` returns a flat list of matches when multiple matches occur

### DIFF
--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -139,21 +139,21 @@ defmodule PhoenixTest.Query do
       end)
 
     results
-    |> Enum.filter(fn
-      :not_found -> false
-      {:not_found, _} -> false
-      {:found, _} -> true
-      {:found_many, _} -> true
+    |> Enum.flat_map(fn
+      :not_found -> []
+      {:not_found, _} -> []
+      {:found, el} -> [el]
+      {:found_many, els} -> els
     end)
     |> case do
       [] ->
         {:not_found, potential_matches(results)}
 
       [found] ->
-        found
+        {:found, found}
 
-      [_, _] = found_many ->
-        {:found_many, Enum.map(found_many, &elem(&1, 1))}
+      [_ | _] = found_many ->
+        {:found_many, found_many}
     end
   end
 

--- a/test/phoenix_test/query_test.exs
+++ b/test/phoenix_test/query_test.exs
@@ -338,12 +338,15 @@ defmodule PhoenixTest.QueryTest do
       html = """
       <h1 id="title">Hello</h1>
       <h2 id="subtitle">Hi</h2>
+      <h2 id="another">Hi again</h2>
       """
 
-      {:found_many, [elem1, elem2]} = Query.find_one_of(html, [{"h1", "Hello"}, {"h2", "Hi"}])
+      {:found_many, [elem1, elem2, elem3]} =
+        Query.find_one_of(html, [{"h1", "Hello"}, {"h2", "Hi"}])
 
       assert {"h1", _, ["Hello"]} = Html.element(elem1)
       assert {"h2", _, ["Hi"]} = Html.element(elem2)
+      assert {"h2", _, ["Hi again"]} = Html.element(elem3)
     end
 
     test "returns :not_found when no selector matches" do


### PR DESCRIPTION
The following test:
```
    test "users can login with email/password", %{conn: conn} do
      user = insert_user()

      conn
      |> visit(~p"/users/log_in")
      |> fill_in("Email", with: user.email)
      |> fill_in("Password", with: valid_user_password())
      |> click_button("Sign in")
      |> assert_path(~p"/")
      |> assert_has("button", text: user.first_name)
    end
```

Was exploding with: (I edited a bit to make it a bit more readable)

```
test/project/live/user_login_live_test.exs:23
     ** (FunctionClauseError) no function clause matching in PhoenixTest.Html.raw/1

     The following arguments were given to PhoenixTest.Html.raw/1:

         # 1
         [#LazyHTML<
             1 node (from selector)
           
             #1
             <a href="/oauth/google" role="button">Sign in with google</a>
           >, #LazyHTML<
             1 node (from selector)
           
             #1
             <a href="/oauth/microsoft" role="button">Sign in with microsoft</a>
           >]

     Attempted function clauses (showing 1 out of 1):

         def raw(%LazyHTML{} = html)

     code: |> click_button("Sign in")
     stacktrace:
       (phoenix_test 0.9.1) lib/phoenix_test/html.ex:71: PhoenixTest.Html.raw/1
       (elixir 1.19.1) lib/enum.ex:1789: anonymous fn/2 in Enum.map_join/3
       (elixir 1.19.1) lib/enum.ex:4552: Enum.map_intersperse_list/3
       (elixir 1.19.1) lib/enum.ex:4555: Enum.map_intersperse_list/3
       (elixir 1.19.1) lib/enum.ex:1789: Enum.map_join/3
       (phoenix_test 0.9.1) lib/phoenix_test/query.ex:129: PhoenixTest.Query.find_one_of!/2
       (phoenix_test 0.9.1) lib/phoenix_test/live.ex:90: PhoenixTest.Live.click_button/2
       test/project/live/user_login_live_test.exs:30: (test)
```

This was caused because when one of the selectors matches multiple elements, the return from `find_one_of` is a nested list.
The form has some oauth buttons (a[role="button"] + a submit button that all have labels matching "Sign In" in the click_button.
