### PR TITLE
Fix: Live click_link/button with data-method

### DIFF
--- a/lib/phoenix_test/element/link.ex
+++ b/lib/phoenix_test/element/link.ex
@@ -7,8 +7,17 @@ defmodule PhoenixTest.Element.Link do
 
   defstruct ~w[parsed id selector text href]a
 
+  def find(html, selector, text) do
+    with {:found, link} <- Query.find(html, selector, text) do
+      {:found, build(link, selector, text)}
+    end
+  end
+
   def find!(html, selector, text) do
-    link = Query.find!(html, selector, text)
+    html |> Query.find!(selector, text) |> build(selector, text)
+  end
+
+  defp build(link, selector, text) do
     id = Html.attribute(link, "id")
     href = Html.attribute(link, "href")
 

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -57,12 +57,7 @@ defmodule PhoenixTest.Static do
     link = Link.find!(session.current_operation.html, selector, text)
 
     if Link.has_data_method?(link) do
-      form =
-        link.parsed
-        |> DataAttributeForm.build()
-        |> DataAttributeForm.validate!(selector, text)
-
-      perform_submit(session, form, form.data)
+      click_with_data_method(session, link)
     else
       conn = session.conn
 
@@ -96,12 +91,7 @@ defmodule PhoenixTest.Static do
     html = session.current_operation.html
 
     if Button.has_data_method?(button) do
-      form =
-        button.parsed
-        |> DataAttributeForm.build()
-        |> DataAttributeForm.validate!(button.selector, button.text)
-
-      perform_submit(session, form, form.data)
+      click_with_data_method(session, button)
     else
       form =
         button
@@ -114,6 +104,15 @@ defmodule PhoenixTest.Static do
         perform_submit(session, form, build_payload(form))
       end
     end
+  end
+
+  def click_with_data_method(session, el) when is_struct(el, Link) or is_struct(el, Button) do
+    form =
+      el.parsed
+      |> DataAttributeForm.build()
+      |> DataAttributeForm.validate!(el.selector, el.text)
+
+    perform_submit(session, form, form.data)
   end
 
   def fill_in(session, label, opts) do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -102,6 +102,13 @@ defmodule PhoenixTest.LiveTest do
       end)
     end
 
+    test "handles form submission via `data-method` & `data-to` attributes", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_link("Data-method Delete")
+      |> assert_has("h1", text: "Record deleted")
+    end
+
     test "raises error when there are multiple links with same text", %{conn: conn} do
       assert_raise ArgumentError, ~r/2 of them matched the text filter/, fn ->
         conn
@@ -246,6 +253,13 @@ defmodule PhoenixTest.LiveTest do
       |> within("#non-liveview-form", &fill_in(&1, "Name", with: "Aragorn"))
       |> click_button("Submit Non LiveView")
       |> assert_has("#form-data", text: "name: Aragorn")
+    end
+
+    test "handles form submission via `data-method` & `data-to` attributes", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_button("Data-method Delete")
+      |> assert_has("h1", text: "Record deleted")
     end
 
     test "Raises an error if button with type 'button' inside form doesn't have valid phx-click", %{conn: conn} do

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -40,6 +40,19 @@ defmodule PhoenixTest.WebApp.IndexLive do
 
     <button phx-click="show-tab">Show tab</button>
 
+    <a
+      href="/page/delete_record"
+      data-method="delete"
+      data-to="/page/delete_record"
+      data-csrf="sometoken"
+    >
+      Data-method Delete
+    </a>
+
+    <button data-method="delete" data-to="/page/delete_record" data-csrf="sometoken">
+      Data-method Delete
+    </button>
+
     <div id="button-with-id-1">
       <button phx-click="show-tab">Duplicate button with wrapped id</button>
     </div>


### PR DESCRIPTION
Handle clicking links and buttons with `data-method` in LiveViews.

The `Static` driver already supports this.
The docs suggest this should work regardless of the driver.

> If the button acts as a form via Phoenix.HTML's data-method, data-to, and data-csrf, this will emulate Phoenix.HTML.js and submit the form via data attributes.
> https://hexdocs.pm/phoenix_test/PhoenixTest.html#click_button/2

> Phoenix allows for submitting forms on links via Phoenix.HTML's data-method, data-to, and data-csrf.
> We can use click_link to emulate Phoenix.HTML.js and submit the form via data attributes.
> https://hexdocs.pm/phoenix_test/PhoenixTest.html#click_link/2