### PR TITLE
Fix: assert_has/refute_has by 'label' incorrect if no 'value' given

### DIFF
--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -441,8 +441,13 @@ defmodule PhoenixTest.Assertions do
   defp maybe_append_position(msg, :any), do: msg
   defp maybe_append_position(msg, position), do: msg <> " at position #{position}"
 
-  defp finder_fun(selector, %Opts{text: :no_text, value: :no_value} = opts, _operation) do
+  defp finder_fun(selector, %Opts{text: :no_text, value: :no_value, label: :no_label} = opts, _operation) do
     &Query.find(&1, selector, Opts.to_list(opts))
+  end
+
+  defp finder_fun(selector, %Opts{text: :no_text, value: :no_value, label: label} = opts, _operation)
+       when is_binary(label) do
+    &Query.find_by_label(&1, selector, label, Opts.to_list(opts))
   end
 
   defp finder_fun(selector, %Opts{text: :no_text, value: value} = opts, _operation) do

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -144,6 +144,20 @@ defmodule PhoenixTest.AssertionsTest do
       |> assert_has("input", label: "Wizard", value: "Gandalf")
     end
 
+    test "assert by label", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> assert_has("input", label: "Hobbit")
+    end
+
+    test "assert by label raises an error if label not found", %{conn: conn} do
+      assert_raise AssertionError, fn ->
+        conn
+        |> visit("/page/by_value")
+        |> assert_has("input", label: "Unknown")
+      end
+    end
+
     test "succeeds when selector matches either node with text, or any ancestor", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -732,6 +746,20 @@ defmodule PhoenixTest.AssertionsTest do
       |> visit("/page/by_value")
       |> refute_has("input", label: "Istari", value: "Gandalf")
       |> refute_has("input", label: "Wizard", value: "Saruman")
+    end
+
+    test "refute by label", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> refute_has("input", label: "Unknown")
+    end
+
+    test "refute by label raises an error if label found", %{conn: conn} do
+      assert_raise AssertionError, fn ->
+        conn
+        |> visit("/page/by_value")
+        |> refute_has("input", label: "Hobbit")
+      end
     end
 
     test "raises an error if value is found", %{conn: conn} do


### PR DESCRIPTION
Fixes #285