### PR TITLE
Add assert_download/2 to test file downloads

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1563,6 +1563,32 @@ defmodule PhoenixTest do
   end
 
   @doc """
+  Assert helper to verify a file download.
+
+  > ### Note on supported download types
+  >
+  > Only downloads with HTTP response header `Content-Type: attachment; filename=...` are supported.
+
+  ## Examples
+
+  ```elixir
+  conn
+  |> visit("/users")
+  |> click_link("Download avatar")
+  |> assert_download("avatar.jpg")
+
+  conn
+  |> visit("/users")
+  |> click_link("Download avatar")
+  |> assert_download(fn %{mime_type: type, content: content} ->
+    assert file.mime_type == "image/jpeg"
+    assert content == File.read!(expected_file_path)
+  end)
+  ```
+  """
+  defdelegate assert_download(session, file_name), to: Driver
+
+  @doc """
   Assert helper to verify current request path. Takes an optional `query_params`
   map.
 

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -250,6 +250,23 @@ defmodule PhoenixTest.Assertions do
     session
   end
 
+  def assert_download(session, _) when not is_struct(session, PhoenixTest.Static) do
+    raise ArgumentError, "Only downloads via Phoenix.Controller are supported."
+  end
+
+  def assert_download(session, fun) when is_function(fun, 1) do
+    session |> PhoenixTest.Static.download_file() |> fun.()
+
+    session
+  end
+
+  def assert_download(session, file_name) when is_binary(file_name) do
+    file = PhoenixTest.Static.download_file(session)
+    assert file.name == file_name
+
+    session
+  end
+
   def assert_path(session, path) do
     session = set_operation(session, :assert_path, "")
     uri = URI.parse(PhoenixTest.Driver.current_path(session))

--- a/lib/phoenix_test/driver.ex
+++ b/lib/phoenix_test/driver.ex
@@ -31,6 +31,7 @@ defprotocol PhoenixTest.Driver do
   def assert_has(session, selector, opts)
   def refute_has(session, selector)
   def refute_has(session, selector, opts)
+  def assert_download(session, file_name)
   def assert_path(session, path)
   def assert_path(session, path, opts)
   def refute_path(session, path)

--- a/lib/phoenix_test/file_download.ex
+++ b/lib/phoenix_test/file_download.ex
@@ -1,0 +1,5 @@
+defmodule PhoenixTest.FileDownload do
+  @moduledoc false
+  @enforce_keys ~w[name mime_type content]a
+  defstruct ~w[name mime_type content]a
+end

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -700,6 +700,7 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   defdelegate assert_has(session, selector, opts), to: Live
   defdelegate refute_has(session, selector), to: Assertions
   defdelegate refute_has(session, selector, opts), to: Live
+  defdelegate assert_download(session, file_name), to: Assertions
   defdelegate assert_path(session, path), to: Assertions
   defdelegate assert_path(session, path, opts), to: Assertions
   defdelegate refute_path(session, path), to: Assertions

--- a/lib/phoenix_test/static.ex
+++ b/lib/phoenix_test/static.ex
@@ -3,6 +3,7 @@ defmodule PhoenixTest.Static do
 
   import Phoenix.ConnTest
 
+  alias ExUnit.AssertionError
   alias PhoenixTest.ActiveForm
   alias PhoenixTest.ConnHandler
   alias PhoenixTest.DataAttributeForm
@@ -12,6 +13,7 @@ defmodule PhoenixTest.Static do
   alias PhoenixTest.Element.Link
   alias PhoenixTest.Element.Select
   alias PhoenixTest.EndpointHelpers
+  alias PhoenixTest.FileDownload
   alias PhoenixTest.FileUpload
   alias PhoenixTest.FormData
   alias PhoenixTest.FormPayload
@@ -49,6 +51,20 @@ defmodule PhoenixTest.Static do
       :none -> html
       selector when is_binary(selector) -> Html.all(html, selector)
     end
+  end
+
+  def download_file(%{conn: conn}) do
+    file_name =
+      case Plug.Conn.get_resp_header(conn, "content-disposition") do
+        ["attachment; filename=\"" <> name | _] -> String.trim_trailing(name, "\"")
+        other -> raise AssertionError, message: "No download detected. Could not find filename in #{inspect(other)}"
+      end
+
+    %FileDownload{
+      mime_type: conn |> Plug.Conn.get_resp_header("content-type") |> List.first(),
+      name: file_name,
+      content: conn.resp_body
+    }
   end
 
   def click_link(session, selector \\ "a", text) do
@@ -374,6 +390,7 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Static do
   defdelegate assert_has(session, selector, opts), to: Assertions
   defdelegate refute_has(session, selector), to: Assertions
   defdelegate refute_has(session, selector, opts), to: Assertions
+  defdelegate assert_download(session, file_name), to: Assertions
   defdelegate assert_path(session, path), to: Assertions
   defdelegate assert_path(session, path, opts), to: Assertions
   defdelegate refute_path(session, path), to: Assertions

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -1484,4 +1484,20 @@ defmodule PhoenixTest.LiveTest do
       |> refute_has("#form-data", text: "version_a_text")
     end
   end
+
+  describe "assert_download" do
+    test "asserts on file name", %{conn: conn} do
+      conn
+      |> visit("/page/download")
+      |> assert_download("elixir.jpg")
+    end
+
+    test "raises on live page", %{conn: conn} do
+      assert_raise ArgumentError, ~r/Phoenix\.Controller/, fn ->
+        conn
+        |> visit("/live/index")
+        |> assert_download("elixir.jpg")
+      end
+    end
+  end
 end

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -4,6 +4,8 @@ defmodule PhoenixTest.StaticTest do
   import PhoenixTest
   import PhoenixTest.TestHelpers
 
+  alias ExUnit.AssertionError
+
   setup do
     %{conn: PhoenixTest.put_endpoint(Phoenix.ConnTest.build_conn(), PhoenixTest.WebApp.Endpoint)}
   end
@@ -945,6 +947,31 @@ defmodule PhoenixTest.StaticTest do
         |> within("#invalid-form", fn session ->
           fill_in(session, "No Name Attribute", with: "random")
         end)
+      end
+    end
+  end
+
+  describe "assert_download" do
+    test "asserts on file name", %{conn: conn} do
+      conn
+      |> visit("/page/download")
+      |> assert_download("elixir.jpg")
+    end
+
+    test "custom assertion via function", %{conn: conn} do
+      conn
+      |> visit("/page/download")
+      |> assert_download(fn file ->
+        assert file.mime_type == "image/jpeg"
+        assert file.content == File.read!("test/files/elixir.jpg")
+      end)
+    end
+
+    test "fails on non-download page", %{conn: conn} do
+      assert_raise AssertionError, ~r/No download detected/, fn ->
+        conn
+        |> visit("/page/index")
+        |> assert_download("elixir.jpg")
       end
     end
   end

--- a/test/support/web_app/page_controller.ex
+++ b/test/support/web_app/page_controller.ex
@@ -52,4 +52,8 @@ defmodule PhoenixTest.WebApp.PageController do
     |> put_status(:unauthorized)
     |> render("unauthorized.html")
   end
+
+  def download(conn, _) do
+    send_download(conn, {:file, "test/files/elixir.jpg"})
+  end
 end

--- a/test/support/web_app/router.ex
+++ b/test/support/web_app/router.ex
@@ -33,6 +33,7 @@ defmodule PhoenixTest.WebApp.Router do
     get "/page/redirect_to_static", PageController, :redirect_to_static
     post "/page/redirect_to_liveview", PageController, :redirect_to_liveview
     post "/page/redirect_to_static", PageController, :redirect_to_static
+    get "/page/download", PageController, :download
     get "/page/:page", PageController, :show
 
     live_session :live_pages, layout: {PhoenixTest.WebApp.LayoutView, :app} do


### PR DESCRIPTION
This is just a copy of #111 (and supersedes it) that has been rebased to bring it up to date with `main`

---------------

## Assert helper to verify a file download.

  > ### Note on supported download types
  >
  > Only downloads with HTTP response header `Content-Type: attachment; filename=...` are supported.

  ## Examples

  ```elixir
  conn
  |> visit("/users")
  |> click_link("Download avatar")
  |> assert_download("avatar.jpg")

  conn
  |> visit("/users")
  |> click_link("Download avatar")
  |> assert_download(fn %{mime_type: type, content: content} ->
    assert file.mime_type == "image/jpeg"
    assert content == File.read!(expected_file_path)
  end)
  ```