### PR TITLE
Add process-local endpoint configuration via `PhoenixTest.Config`

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -49,10 +49,24 @@ defmodule PhoenixTest do
 
   PhoenixTest needs to know which endpoint to use for routing requests.
 
-  There are two ways of doing this:
+  There are three ways of doing this:
 
-  1. You can specify the endpoint at runtime in your `ConnCase` (or equivalent)
-  setup block:
+  1. You can set it per-test-process in your `ConnCase` (or equivalent) setup
+  block. This is the recommended approach for umbrella apps, multi-endpoint
+  setups, and compatibility with external drivers like `phoenix_test_playwright`:
+
+  ```elixir
+  setup do
+    PhoenixTest.Config.put_endpoint(MyAppWeb.Endpoint)
+    {:ok, conn: Phoenix.ConnTest.build_conn()}
+  end
+  ```
+
+  This stores the endpoint in the process dictionary, so it's parallel-safe -
+  different test suites can use different endpoints without interfering with
+  each other.
+
+  2. You can specify the endpoint on the conn directly in your setup block:
 
   ```elixir
   setup tags do
@@ -62,13 +76,17 @@ defmodule PhoenixTest do
   end
   ```
 
-  NOTE that this opens the option for umbrella apps to have different endpoints.
+  NOTE: `put_endpoint/2` also sets the process-level config, so external
+  drivers can resolve the endpoint too.
 
-  2. You can set it at compile time in `config/test.exs`:
+  3. You can set a global fallback in `config/test.exs`:
 
   ```elixir
   config :phoenix_test, :endpoint, MyAppWeb.Endpoint
   ```
+
+  NOTE: This is a global setting shared across all tests. For umbrella apps or
+  multi-endpoint setups, prefer option 1 or 2 above.
 
   ### Getting `PhoenixTest` helpers
 
@@ -122,10 +140,54 @@ defmodule PhoenixTest do
       pid = Ecto.Adapters.SQL.Sandbox.start_owner!(MyApp.Repo, shared: not tags[:async])
       on_exit(fn -> Ecto.Adapters.SQL.Sandbox.stop_owner(pid) end)
 
-      {:ok, conn: Phoenix.ConnTest.build_conn() |> PhoenixTest.put_endpoint(MyAppWeb.Endpoint)}
+      PhoenixTest.Config.put_endpoint(MyAppWeb.Endpoint)
+      {:ok, conn: Phoenix.ConnTest.build_conn()}
     end
   end
   ```
+
+  ### Umbrella apps / multiple endpoints
+
+  In umbrella apps, each child application typically has its own endpoint.
+  Create a separate `FeatureCase` (or `ConnCase`) for each app, each calling
+  `PhoenixTest.Config.put_endpoint/1` with the correct endpoint:
+
+  ```elixir
+  # apps/app_a/test/support/feature_case.ex
+  defmodule AppAWeb.FeatureCase do
+    use ExUnit.CaseTemplate
+
+    using do
+      quote do
+        import PhoenixTest
+      end
+    end
+
+    setup do
+      PhoenixTest.Config.put_endpoint(AppAWeb.Endpoint)
+      {:ok, conn: Phoenix.ConnTest.build_conn()}
+    end
+  end
+
+  # apps/app_b/test/support/feature_case.ex
+  defmodule AppBWeb.FeatureCase do
+    use ExUnit.CaseTemplate
+
+    using do
+      quote do
+        import PhoenixTest
+      end
+    end
+
+    setup do
+      PhoenixTest.Config.put_endpoint(AppBWeb.Endpoint)
+      {:ok, conn: Phoenix.ConnTest.build_conn()}
+    end
+  end
+  ```
+
+  Since each test runs in its own process, these can run in parallel with
+  `async: true` without interfering with each other.
 
   Note that we assume your Phoenix project is using Ecto and its phenomenal
   `SQL.Sandbox`. If it doesn't, feel free to remove the `SQL.Sandbox` code
@@ -225,7 +287,9 @@ defmodule PhoenixTest do
   @doc """
   Sets the endpoint on the conn so PhoenixTest knows which endpoint to use.
 
-  Call this in your test setup with your app's endpoint module.
+  Also stores the endpoint in the process dictionary so that external drivers
+  (e.g. `phoenix_test_playwright`) can resolve the endpoint for the current
+  test process.
 
   ## Examples
 
@@ -236,6 +300,7 @@ defmodule PhoenixTest do
   ```
   """
   def put_endpoint(conn, endpoint) do
+    PhoenixTest.Config.put_endpoint(endpoint)
     Plug.Conn.put_private(conn, :phoenix_endpoint, endpoint)
   end
 

--- a/lib/phoenix_test/config.ex
+++ b/lib/phoenix_test/config.ex
@@ -1,0 +1,36 @@
+defmodule PhoenixTest.Config do
+  @moduledoc false
+
+  @process_key :phoenix_test_endpoint
+
+  def put_endpoint(endpoint) when is_atom(endpoint) do
+    Process.put(@process_key, endpoint)
+    :ok
+  end
+
+  def endpoint do
+    Process.get(@process_key) || Application.get_env(:phoenix_test, :endpoint)
+  end
+
+  def endpoint! do
+    endpoint() ||
+      raise ArgumentError, """
+      No endpoint configured for PhoenixTest.
+
+      Set it per-test-process in your test setup (recommended for umbrella apps):
+
+          setup do
+            PhoenixTest.Config.put_endpoint(MyAppWeb.Endpoint)
+            :ok
+          end
+
+      Or set it on the conn directly:
+
+          {:ok, conn: Phoenix.ConnTest.build_conn() |> PhoenixTest.put_endpoint(MyAppWeb.Endpoint)}
+
+      Or set it globally in config/test.exs:
+
+          config :phoenix_test, :endpoint, MyAppWeb.Endpoint
+      """
+  end
+end

--- a/lib/phoenix_test/endpoint_helpers.ex
+++ b/lib/phoenix_test/endpoint_helpers.ex
@@ -2,22 +2,30 @@ defmodule PhoenixTest.EndpointHelpers do
   @moduledoc false
 
   # This module replaces Phoenix test macros that require `@endpoint` to be set
-  # as a compile-time module attribute. Instead, the endpoint is read at runtime
-  # from `conn.private[:phoenix_endpoint]`, set via `PhoenixTest.put_endpoint/2`.
+  # as a compile-time module attribute. Instead, the endpoint is resolved at
+  # runtime through a chain: conn.private -> process dictionary -> Application config.
+  # See `PhoenixTest.Config` for details on the resolution order.
 
   def endpoint_from!(conn) do
     conn.private[:phoenix_endpoint] ||
-      Application.get_env(:phoenix_test, :endpoint) ||
+      PhoenixTest.Config.endpoint() ||
       raise ArgumentError, """
-      No endpoint set on conn. Use PhoenixTest.put_endpoint/2 in your test setup:
+      No endpoint set. Configure it using one of these approaches:
 
-        ```elixir
-        conn =
-          Phoenix.ConnTest.build_conn()
-          |> PhoenixTest.put_endpoint(MyAppWeb.Endpoint)
-        ```
+      1. Per-test-process (recommended for umbrella apps / multiple endpoints):
 
-      Or configure the endpoint in your test config:
+          setup do
+            PhoenixTest.Config.put_endpoint(MyAppWeb.Endpoint)
+            :ok
+          end
+
+      2. Per-conn:
+
+          conn =
+            Phoenix.ConnTest.build_conn()
+            |> PhoenixTest.put_endpoint(MyAppWeb.Endpoint)
+
+      3. Global fallback in config/test.exs:
 
           config :phoenix_test, :endpoint, MyAppWeb.Endpoint
       """

--- a/test/phoenix_test/config_test.exs
+++ b/test/phoenix_test/config_test.exs
@@ -1,0 +1,54 @@
+defmodule PhoenixTest.ConfigTest do
+  use ExUnit.Case, async: true
+
+  alias PhoenixTest.Config
+
+  describe "put_endpoint/1 and endpoint/0" do
+    test "stores and retrieves endpoint for current process" do
+      Config.put_endpoint(PhoenixTest.WebApp.Endpoint)
+      assert Config.endpoint() == PhoenixTest.WebApp.Endpoint
+    end
+
+    test "different processes see different endpoints" do
+      Config.put_endpoint(PhoenixTest.WebApp.Endpoint)
+
+      task =
+        Task.async(fn ->
+          Config.put_endpoint(PhoenixTest.AnotherWebApp.Endpoint)
+          Config.endpoint()
+        end)
+
+      other_process_endpoint = Task.await(task)
+
+      assert Config.endpoint() == PhoenixTest.WebApp.Endpoint
+      assert other_process_endpoint == PhoenixTest.AnotherWebApp.Endpoint
+    end
+
+    test "process without put_endpoint falls back to Application config" do
+      Process.delete(:phoenix_test_endpoint)
+
+      assert Config.endpoint() == PhoenixTest.WebApp.Endpoint
+    end
+  end
+
+  describe "endpoint!/0" do
+    test "returns endpoint when set via put_endpoint" do
+      Config.put_endpoint(PhoenixTest.WebApp.Endpoint)
+      assert Config.endpoint!() == PhoenixTest.WebApp.Endpoint
+    end
+
+    test "raises when no endpoint configured" do
+      Process.delete(:phoenix_test_endpoint)
+      original = Application.get_env(:phoenix_test, :endpoint)
+      Application.delete_env(:phoenix_test, :endpoint)
+
+      try do
+        assert_raise ArgumentError, ~r/No endpoint configured/, fn ->
+          Config.endpoint!()
+        end
+      after
+        if original, do: Application.put_env(:phoenix_test, :endpoint, original)
+      end
+    end
+  end
+end

--- a/test/phoenix_test/multi_endpoint_test.exs
+++ b/test/phoenix_test/multi_endpoint_test.exs
@@ -1,0 +1,38 @@
+defmodule PhoenixTest.MultiEndpointTest do
+  use ExUnit.Case, async: true
+
+  import PhoenixTest
+
+  describe "parallel tests with different endpoints via Config" do
+    test "test using WebApp endpoint via Config.put_endpoint" do
+      PhoenixTest.Config.put_endpoint(PhoenixTest.WebApp.Endpoint)
+
+      Phoenix.ConnTest.build_conn()
+      |> visit("/page/index")
+      |> assert_has("h1", text: "Main page")
+    end
+
+    test "test using AnotherWebApp endpoint via Config.put_endpoint" do
+      PhoenixTest.Config.put_endpoint(PhoenixTest.AnotherWebApp.Endpoint)
+
+      Phoenix.ConnTest.build_conn()
+      |> visit("/page")
+      |> assert_has("h1", text: "AnotherWebApp page")
+    end
+
+    test "put_endpoint/2 on conn also sets process-level config" do
+      conn = PhoenixTest.put_endpoint(Phoenix.ConnTest.build_conn(), PhoenixTest.AnotherWebApp.Endpoint)
+
+      assert PhoenixTest.Config.endpoint() == PhoenixTest.AnotherWebApp.Endpoint
+      assert conn.private[:phoenix_endpoint] == PhoenixTest.AnotherWebApp.Endpoint
+    end
+
+    test "conn.private endpoint takes precedence over process config" do
+      PhoenixTest.Config.put_endpoint(PhoenixTest.AnotherWebApp.Endpoint)
+
+      PhoenixTest.put_endpoint(Phoenix.ConnTest.build_conn(), PhoenixTest.WebApp.Endpoint)
+      |> visit("/page/index")
+      |> assert_has("h1", text: "Main page")
+    end
+  end
+end


### PR DESCRIPTION
### Problem

When using `phoenix_test`, the endpoint needs to vary depending on which test suite is running. In umbrella apps or projects with multiple Phoenix endpoints, `Application.get_env(:phoenix_test, :endpoint)` is global, so it can't differ per test suite and isn't safe when running tests in parallel. `put_endpoint/2` solves this for standard PhoenixTest (it sets conn.private), but external drivers like `phoenix_test_playwright` read the endpoint from Application config directly since they don't use `Plug.Conn`.

### Solution

Introduce `PhoenixTest.Config.put_endpoint/1` which stores the endpoint in the process dictionary. Since each `ExUnit` test runs in its own process, different test suites can set different endpoints without interfering with each other.

Endpoint resolution chain:
1. `conn.private[:phoenix_endpoint]` (per-conn)
3. Process dictionary (per-test-process) — new
5. `Application.get_env(:phoenix_test, :endpoint)` (global fallback)

`put_endpoint/2` now also sets the process-level config, so both approaches stay in sync.

 ### Usage

 ```elixir
   # In each ConnCase/FeatureCase:
   setup do
     PhoenixTest.Config.put_endpoint(MyAppWeb.Endpoint)
     {:ok, conn: Phoenix.ConnTest.build_conn()}
   end
 ```

 Fully backward-compatible - existing config :phoenix_test, :endpoint setups continue to work unchanged.