### PR TITLE
Support assert_has value finder for select

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1342,13 +1342,14 @@ defmodule PhoenixTest do
   It'll raise an error if no elements are found, but it will _not_ raise if more
   than one matching element is found (unless `:count` option is used).
 
-  You can assert an element's contents using `:text` or assert a field's value
-  using `:value` (with an optional `:label`). For `select` elements, `:value`
-  refers to the currently selected option's text.
+  You can assert an element's contents using `:text`, assert a field's value
+  using `:value` (with an optional `:label`), or assert a `select` element's
+  selected option text using `:selected`.
 
-  NOTE that you cannot specify both `:text` and `:value` as options.
+  NOTE that you cannot specify more than one of `:text`, `:value`, and
+  `:selected` as options.
 
-  The `:text` or `:value` option can be a binary or anything for which
+  The `:text`, `:value`, or `:selected` option can be a binary or anything for which
   there is an implementation of the `Phoenix.HTML.Safe` protocol. PhoenixTest
   uses that protocol to convert the argument to a binary then looks for the
   converted value.
@@ -1357,18 +1358,18 @@ defmodule PhoenixTest do
 
   - `text`: the text contents to look for.
 
-  - `value`: the element's value to look for. For a `select`, this is the
-  selected option's text, not the option's `value` attribute or any available
-  option.
+  - `value`: the element's `value` attribute to look for.
 
-  - `label`: the label associated to the form field with `value`
+  - `selected`: the selected option's text to look for on a `select`.
+
+  - `label`: the label associated to the form field with `value` or `selected`
 
   - `exact`: by default `assert_has/3` will perform a substring match (e.g. `a
   =~ b`). That makes it easier to assert text within HTML elements that also
   contain other HTML elements. But sometimes we want to assert the exact text is
-  present. For that, use `exact: true`. Note: when used with `:value`, the
-  exactness applies to the label's text, not the input's value. (defaults to
-  `false`)
+  present. For that, use `exact: true`. Note: when used with `:value` or
+  `:selected`, the exactness applies to the label's text, not the field value
+  or selected option. (defaults to `false`)
 
   - `count`: the number of items you expect to match CSS selector (and `text` or
   `value` if provided)
@@ -1398,7 +1399,7 @@ defmodule PhoenixTest do
   assert_has(session, "input", value: "Frodo", label: "Hobbit")
 
   # assert there's a select labeled by "Race" with the "Elf" option selected
-  assert_has(session, "select", value: "Elf", label: "Race")
+  assert_has(session, "select", selected: "Elf", label: "Race")
 
   # assert there are two elements with class "posts"
   assert_has(session, ".posts", count: 2)
@@ -1474,9 +1475,10 @@ defmodule PhoenixTest do
 
   It'll raise an error if any elements that match selector and options.
 
-  NOTE that you cannot specify both `:text` and `:value` as options.
+  NOTE that you cannot specify more than one of `:text`, `:value`, and
+  `:selected` as options.
 
-  The `:text` or `:value` option can be a binary or anything for which
+  The `:text`, `:value`, or `:selected` option can be a binary or anything for which
   there is an implementation of the `Phoenix.HTML.Safe` protocol. PhoenixTest
   uses that protocol to convert the argument to a binary, then looks for the
   converted value.
@@ -1485,18 +1487,18 @@ defmodule PhoenixTest do
 
   - `text`: the text filter to look for.
 
-  - `value`: the element's value to look for. For a `select`, this is the
-  selected option's text, not the option's `value` attribute or any available
-  option.
+  - `value`: the element's `value` attribute to look for.
 
-  - `label`: the label associated to the form field with `value`
+  - `selected`: the selected option's text to look for on a `select`.
+
+  - `label`: the label associated to the form field with `value` or `selected`
 
   - `exact`: by default `refute_has/3` will perform a substring match (e.g. `a
   =~ b`). That makes it easier to refute text within HTML elements that also
   contain other HTML elements. But sometimes we want to refute the exact text is
-  absent. For that, use `exact: true`. Note: when used with `:value`, the
-  exactness applies to the label's text, not the input's value. (defaults to
-  `false`)
+  absent. For that, use `exact: true`. Note: when used with `:value` or
+  `:selected`, the exactness applies to the label's text, not the field value
+  or selected option. (defaults to `false`)
 
   - `count`: the number of items you're expecting _should not_ match the CSS
   selector (and `text` or `value` if provided)
@@ -1524,7 +1526,7 @@ defmodule PhoenixTest do
   refute_has(session, "input", value: "Frodo", label: "Hobbit")
 
   # refute there's a select labeled by "Race" with the "Human" option selected
-  refute_has(session, "select", value: "Human", label: "Race")
+  refute_has(session, "select", selected: "Human", label: "Race")
 
   # refute there are two elements with class "posts" (less or more will not raise)
   refute_has(session, ".posts", count: 2)

--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1358,7 +1358,7 @@ defmodule PhoenixTest do
 
   - `text`: the text contents to look for.
 
-  - `value`: the element's `value` attribute to look for.
+  - `value`: the element's value to look for.
 
   - `selected`: the selected option's text to look for on a `select`.
 
@@ -1487,7 +1487,7 @@ defmodule PhoenixTest do
 
   - `text`: the text filter to look for.
 
-  - `value`: the element's `value` attribute to look for.
+  - `value`: the element's value to look for.
 
   - `selected`: the selected option's text to look for on a `select`.
 

--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1343,7 +1343,8 @@ defmodule PhoenixTest do
   than one matching element is found (unless `:count` option is used).
 
   You can assert an element's contents using `:text` or assert a field's value
-  using `:value` (with an optional `:label`).
+  using `:value` (with an optional `:label`). For `select` elements, `:value`
+  refers to the currently selected option's text.
 
   NOTE that you cannot specify both `:text` and `:value` as options.
 
@@ -1356,7 +1357,9 @@ defmodule PhoenixTest do
 
   - `text`: the text contents to look for.
 
-  - `value`: the element's value to look for.
+  - `value`: the element's value to look for. For a `select`, this is the
+  selected option's text, not the option's `value` attribute or any available
+  option.
 
   - `label`: the label associated to the form field with `value`
 
@@ -1393,6 +1396,9 @@ defmodule PhoenixTest do
 
   # assert there's an input with value "Frodo" labeled by "Hobbit"
   assert_has(session, "input", value: "Frodo", label: "Hobbit")
+
+  # assert there's a select labeled by "Race" with the "Elf" option selected
+  assert_has(session, "select", value: "Elf", label: "Race")
 
   # assert there are two elements with class "posts"
   assert_has(session, ".posts", count: 2)
@@ -1479,7 +1485,9 @@ defmodule PhoenixTest do
 
   - `text`: the text filter to look for.
 
-  - `value`: the element's value to look for.
+  - `value`: the element's value to look for. For a `select`, this is the
+  selected option's text, not the option's `value` attribute or any available
+  option.
 
   - `label`: the label associated to the form field with `value`
 
@@ -1514,6 +1522,9 @@ defmodule PhoenixTest do
 
   # refute there's an input with value "Frodo" and label "Hobbit"
   refute_has(session, "input", value: "Frodo", label: "Hobbit")
+
+  # refute there's a select labeled by "Race" with the "Human" option selected
+  refute_has(session, "select", value: "Human", label: "Race")
 
   # refute there are two elements with class "posts" (less or more will not raise)
   refute_has(session, ".posts", count: 2)

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -17,6 +17,7 @@ defmodule PhoenixTest.Assertions do
       :count,
       :exact,
       :label,
+      :selected,
       :text,
       :value
     ]
@@ -26,6 +27,7 @@ defmodule PhoenixTest.Assertions do
       count = Keyword.get(opts, :count, :any)
       exact = Keyword.get(opts, :exact, false)
       label = Keyword.get(opts, :label, :no_label)
+      selected = Keyword.get(opts, :selected, :no_selected)
       text = Keyword.get(opts, :text, :no_text)
       value = Keyword.get(opts, :value, :no_value)
 
@@ -34,6 +36,7 @@ defmodule PhoenixTest.Assertions do
         count: count,
         exact: exact,
         label: label,
+        selected: selected,
         text: text,
         value: value
       }
@@ -45,6 +48,7 @@ defmodule PhoenixTest.Assertions do
         count: opts.count,
         exact: opts.exact,
         label: opts.label,
+        selected: opts.selected,
         text: opts.text,
         value: opts.value
       ]
@@ -389,6 +393,7 @@ defmodule PhoenixTest.Assertions do
     "Expected #{count_elements(opts.count)} with #{inspect(selector)}"
     |> maybe_append_text(opts.text)
     |> maybe_append_value(opts.value)
+    |> maybe_append_selected(opts.selected)
     |> maybe_append_label(opts.label)
     |> append_found(found)
   end
@@ -397,6 +402,7 @@ defmodule PhoenixTest.Assertions do
     "Could not find #{count_elements(opts.count)} with selector #{inspect(selector)}"
     |> maybe_append_text(opts.text)
     |> maybe_append_value(opts.value)
+    |> maybe_append_selected(opts.selected)
     |> maybe_append_label(opts.label)
     |> maybe_append_position(opts.at)
     |> append_found_other_matches(selector, other_matches)
@@ -406,6 +412,7 @@ defmodule PhoenixTest.Assertions do
     "Expected not to find #{count_elements(opts.count)} with selector #{inspect(selector)}"
     |> maybe_append_text(opts.text)
     |> maybe_append_value(opts.value)
+    |> maybe_append_selected(opts.selected)
     |> maybe_append_label(opts.label)
     |> maybe_append_position(opts.at)
     |> append_found(found)
@@ -435,35 +442,58 @@ defmodule PhoenixTest.Assertions do
   defp maybe_append_value(msg, :no_value), do: msg
   defp maybe_append_value(msg, value), do: msg <> " and value #{inspect(value)}"
 
+  defp maybe_append_selected(msg, :no_selected), do: msg
+  defp maybe_append_selected(msg, selected), do: msg <> " and selected #{inspect(selected)}"
+
   defp maybe_append_label(msg, :no_label), do: msg
   defp maybe_append_label(msg, label), do: msg <> " with label #{inspect(label)}"
 
   defp maybe_append_position(msg, :any), do: msg
   defp maybe_append_position(msg, position), do: msg <> " at position #{position}"
 
-  defp finder_fun(selector, %Opts{text: :no_text, value: :no_value, label: :no_label} = opts, _operation) do
+  defp finder_fun(
+         selector,
+         %Opts{text: :no_text, value: :no_value, selected: :no_selected, label: :no_label} = opts,
+         _operation
+       ) do
     &Query.find(&1, selector, Opts.to_list(opts))
   end
 
-  defp finder_fun(selector, %Opts{text: :no_text, value: :no_value, label: label} = opts, _operation)
+  defp finder_fun(
+         selector,
+         %Opts{text: :no_text, value: :no_value, selected: :no_selected, label: label} = opts,
+         _operation
+       )
        when is_binary(label) do
     &Query.find_by_label(&1, selector, label, Opts.to_list(opts))
   end
 
-  defp finder_fun(selector, %Opts{text: :no_text, value: value} = opts, _operation) do
+  defp finder_fun(selector, %Opts{text: :no_text, value: :no_value, selected: :no_selected} = opts, _operation) do
+    &Query.find(&1, selector, Opts.to_list(opts))
+  end
+
+  defp finder_fun(selector, %Opts{text: :no_text, value: value, selected: :no_selected} = opts, _operation) do
     value_finder_fun(ensure_binary(value), selector, opts)
   end
 
-  defp finder_fun(selector, %Opts{text: text, value: :no_value, count: :any, at: :any} = opts, :assert_has) do
+  defp finder_fun(selector, %Opts{text: :no_text, value: :no_value, selected: selected} = opts, _operation) do
+    selected_finder_fun(ensure_binary(selected), selector, opts)
+  end
+
+  defp finder_fun(
+         selector,
+         %Opts{text: text, value: :no_value, selected: :no_selected, count: :any, at: :any} = opts,
+         :assert_has
+       ) do
     &Query.find_first(&1, selector, ensure_binary(text), Opts.to_list(opts))
   end
 
-  defp finder_fun(selector, %Opts{text: text, value: :no_value} = opts, _operation) do
+  defp finder_fun(selector, %Opts{text: text, value: :no_value, selected: :no_selected} = opts, _operation) do
     &Query.find(&1, selector, ensure_binary(text), Opts.to_list(opts))
   end
 
   defp finder_fun(_selector, %Opts{}, _operation) do
-    raise ArgumentError, "Cannot provide both :text and :value to assertions"
+    raise ArgumentError, "Cannot provide more than one of :text, :value, and :selected to assertions"
   end
 
   defp value_finder_fun(value, selector, %Opts{} = opts) do
@@ -473,6 +503,16 @@ defmodule PhoenixTest.Assertions do
 
       label when is_binary(label) ->
         &Query.find_by_label_and_value(&1, selector, label, value, Opts.to_list(opts))
+    end
+  end
+
+  defp selected_finder_fun(selected, selector, %Opts{} = opts) do
+    case opts.label do
+      :no_label ->
+        &Query.find_by_selected(&1, selector, selected, Opts.to_list(opts))
+
+      label when is_binary(label) ->
+        &Query.find_by_label_and_selected(&1, selector, label, selected, Opts.to_list(opts))
     end
   end
 

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -468,10 +468,6 @@ defmodule PhoenixTest.Assertions do
     &Query.find_by_label(&1, selector, label, Opts.to_list(opts))
   end
 
-  defp finder_fun(selector, %Opts{text: :no_text, value: :no_value, selected: :no_selected} = opts, _operation) do
-    &Query.find(&1, selector, Opts.to_list(opts))
-  end
-
   defp finder_fun(selector, %Opts{text: :no_text, value: value, selected: :no_selected} = opts, _operation) do
     value_finder_fun(ensure_binary(value), selector, opts)
   end

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -467,14 +467,12 @@ defmodule PhoenixTest.Assertions do
   end
 
   defp value_finder_fun(value, selector, %Opts{} = opts) do
-    selector = selector <> "[value=#{inspect(value)}]"
-
     case opts.label do
       :no_label ->
-        &Query.find(&1, selector, Opts.to_list(opts))
+        &Query.find_by_value(&1, selector, value, Opts.to_list(opts))
 
       label when is_binary(label) ->
-        &Query.find_by_label(&1, selector, label, Opts.to_list(opts))
+        &Query.find_by_label_and_value(&1, selector, label, value, Opts.to_list(opts))
     end
   end
 

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -4,7 +4,6 @@ defmodule PhoenixTest.Assertions do
   import ExUnit.Assertions
 
   alias ExUnit.AssertionError
-  alias Phoenix.HTML.Safe
   alias PhoenixTest.Html
   alias PhoenixTest.Operation
   alias PhoenixTest.Query
@@ -451,71 +450,49 @@ defmodule PhoenixTest.Assertions do
   defp maybe_append_position(msg, :any), do: msg
   defp maybe_append_position(msg, position), do: msg <> " at position #{position}"
 
-  defp finder_fun(
-         selector,
-         %Opts{text: :no_text, value: :no_value, selected: :no_selected, label: :no_label} = opts,
-         _operation
-       ) do
-    &Query.find(&1, selector, Opts.to_list(opts))
-  end
+  defp finder_fun(selector, %Opts{} = opts, operation) do
+    content =
+      opts
+      |> Map.take(~w(text value selected)a)
+      |> Enum.reject(&(&1 in [text: :no_text, value: :no_value, selected: :no_selected]))
 
-  defp finder_fun(
-         selector,
-         %Opts{text: :no_text, value: :no_value, selected: :no_selected, label: label} = opts,
-         _operation
-       )
-       when is_binary(label) do
-    &Query.find_by_label(&1, selector, label, Opts.to_list(opts))
-  end
+    case {content, opts, operation} do
+      {[], %Opts{label: :no_label}, _} ->
+        &Query.find(&1, selector, Opts.to_list(opts))
 
-  defp finder_fun(selector, %Opts{text: :no_text, value: value, selected: :no_selected} = opts, _operation) do
-    value_finder_fun(ensure_binary(value), selector, opts)
-  end
+      {[], %Opts{label: label}, _} when is_binary(label) ->
+        &Query.find_by_label(&1, selector, label, Opts.to_list(opts))
 
-  defp finder_fun(selector, %Opts{text: :no_text, value: :no_value, selected: selected} = opts, _operation) do
-    selected_finder_fun(ensure_binary(selected), selector, opts)
-  end
+      {[value: value], %Opts{label: :no_label}, _} ->
+        &Query.find_by_value(&1, selector, ensure_binary(value), Opts.to_list(opts))
 
-  defp finder_fun(
-         selector,
-         %Opts{text: text, value: :no_value, selected: :no_selected, count: :any, at: :any} = opts,
-         :assert_has
-       ) do
-    &Query.find_first(&1, selector, ensure_binary(text), Opts.to_list(opts))
-  end
+      {[value: value], %Opts{label: label}, _} when is_binary(label) ->
+        &Query.find_by_label_and_value(&1, selector, label, ensure_binary(value), Opts.to_list(opts))
 
-  defp finder_fun(selector, %Opts{text: text, value: :no_value, selected: :no_selected} = opts, _operation) do
-    &Query.find(&1, selector, ensure_binary(text), Opts.to_list(opts))
-  end
+      {[selected: selected], %Opts{label: :no_label}, _} ->
+        &Query.find_by_selected(&1, selector, ensure_binary(selected), Opts.to_list(opts))
 
-  defp finder_fun(_selector, %Opts{}, _operation) do
-    raise ArgumentError, "Cannot provide more than one of :text, :value, and :selected to assertions"
-  end
+      {[selected: selected], %Opts{label: label}, _} when is_binary(label) ->
+        &Query.find_by_label_and_selected(&1, selector, label, ensure_binary(selected), Opts.to_list(opts))
 
-  defp value_finder_fun(value, selector, %Opts{} = opts) do
-    case opts.label do
-      :no_label ->
-        &Query.find_by_value(&1, selector, value, Opts.to_list(opts))
+      {[text: text], %Opts{label: :no_label, count: :any, at: :any}, :assert_has} ->
+        &Query.find_first(&1, selector, ensure_binary(text), Opts.to_list(opts))
 
-      label when is_binary(label) ->
-        &Query.find_by_label_and_value(&1, selector, label, value, Opts.to_list(opts))
-    end
-  end
+      {[text: text], %Opts{label: :no_label}, _} ->
+        &Query.find(&1, selector, ensure_binary(text), Opts.to_list(opts))
 
-  defp selected_finder_fun(selected, selector, %Opts{} = opts) do
-    case opts.label do
-      :no_label ->
-        &Query.find_by_selected(&1, selector, selected, Opts.to_list(opts))
+      {[text: _text], %Opts{}, _} ->
+        raise ArgumentError, "Cannot provide :label with :text to assertions"
 
-      label when is_binary(label) ->
-        &Query.find_by_label_and_selected(&1, selector, label, selected, Opts.to_list(opts))
+      _ ->
+        raise ArgumentError, "Cannot pass more than one of options :text, :value, :selected to assertions"
     end
   end
 
   defp ensure_binary(value) when is_binary(value), do: value
 
   defp ensure_binary(value) do
-    value |> Safe.to_iodata() |> IO.iodata_to_binary()
+    value |> Phoenix.HTML.Safe.to_iodata() |> IO.iodata_to_binary()
   end
 
   defp format_found_elements(elements) when is_list(elements) do

--- a/lib/phoenix_test/element/form.ex
+++ b/lib/phoenix_test/element/form.ex
@@ -123,26 +123,9 @@ defmodule PhoenixTest.Element.Form do
     form
     |> Html.all("select:not([disabled])")
     |> Enum.flat_map(fn select ->
-      selected_options = Html.all(select, "option[selected]")
-      multiple? = Html.attribute(select, "multiple") != nil
-
-      case {multiple?, Enum.count(selected_options)} do
-        {true, 0} ->
-          []
-
-        {false, 0} ->
-          if option = select |> Html.all("option") |> Enum.at(0) do
-            [to_form_field(select, option)]
-          else
-            []
-          end
-
-        {false, _} ->
-          [to_form_field(select, selected_options)]
-
-        _ ->
-          Enum.map(selected_options, &to_form_field(select, &1))
-      end
+      select
+      |> Html.selected_options()
+      |> Enum.map(&to_form_field(select, &1))
     end)
   end
 

--- a/lib/phoenix_test/html.ex
+++ b/lib/phoenix_test/html.ex
@@ -70,13 +70,12 @@ defmodule PhoenixTest.Html do
 
   def selected_options(%LazyHTML{} = select) do
     selected_options = all(select, "option[selected]")
+    all_options = all(select, "option")
 
-    if attribute(select, "multiple") do
-      selected_options
-    else
-      selected_options
-      |> Stream.concat(all(select, "option"))
-      |> Enum.take(1)
+    cond do
+      attribute(select, "multiple") -> selected_options
+      Enum.empty?(selected_options) -> Enum.take(all_options, 1)
+      true -> Enum.take(selected_options, 1)
     end
   end
 

--- a/lib/phoenix_test/html.ex
+++ b/lib/phoenix_test/html.ex
@@ -68,6 +68,18 @@ defmodule PhoenixTest.Html do
     LazyHTML.query(html, selector)
   end
 
+  def selected_options(%LazyHTML{} = select) do
+    selected_options = all(select, "option[selected]")
+
+    if attribute(select, "multiple") do
+      selected_options
+    else
+      selected_options
+      |> Stream.concat(all(select, "option"))
+      |> Enum.take(1)
+    end
+  end
+
   def raw(%LazyHTML{} = html), do: LazyHTML.to_html(html)
 
   def postwalk(%LazyHTML{} = html, postwalk_fun) when is_function(postwalk_fun, 1) do

--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -57,8 +57,7 @@ defmodule PhoenixTest.Query do
 
   def find(html, selector, opts) when is_list(opts) do
     html
-    |> Html.parse_fragment()
-    |> Html.all(selector)
+    |> all_by_selector(selector)
     |> filter_by_position(opts)
     |> case do
       [] ->
@@ -74,18 +73,32 @@ defmodule PhoenixTest.Query do
   end
 
   def find(html, selector, text, opts \\ []) when is_binary(text) and is_list(opts) do
-    elements_matched_selector =
-      html
-      |> Html.parse_fragment()
-      |> Html.all(selector)
+    elements_matched_selector = all_by_selector(html, selector)
 
     elements_matched_selector
     |> filter_by_position(opts)
     |> filter_by_element_text(text, opts)
-    |> case do
-      [] -> {:not_found, elements_matched_selector}
-      [found] -> {:found, found}
-      [_ | _] = found_many -> {:found_many, found_many}
+    |> find_result(elements_matched_selector)
+  end
+
+  def find_by_value(html, selector, value, opts \\ []) when is_binary(value) and is_list(opts) do
+    elements_matched_selector = all_by_selector(html, selector)
+
+    elements_matched_selector
+    |> filter_by_position(opts)
+    |> find_by_element_value_result(value, elements_matched_selector)
+  end
+
+  def find_by_label_and_value(html, input_selectors, label, value, opts \\ []) when is_binary(value) and is_list(opts) do
+    case find_by_label(html, input_selectors, label, opts) do
+      {:found, element} ->
+        find_by_element_value_result([element], value, [element])
+
+      {:not_found, :found_many_labels_with_inputs, _labels, elements} ->
+        find_by_element_value_result(elements, value, elements)
+
+      other ->
+        other
     end
   end
 
@@ -93,10 +106,7 @@ defmodule PhoenixTest.Query do
   #
   # This is a performance improvement when you only need to confirm that at least one match exists.
   def find_first(html, selector, text, opts \\ []) when is_binary(text) and is_list(opts) do
-    elements_matched_selector =
-      html
-      |> Html.parse_fragment()
-      |> Html.all(selector)
+    elements_matched_selector = all_by_selector(html, selector)
 
     case find_first_by_element_text(elements_matched_selector, text, opts) do
       nil -> {:not_found, elements_matched_selector}
@@ -557,6 +567,43 @@ defmodule PhoenixTest.Query do
     else
       Enum.find(elements, &(Html.element_text(&1) =~ text))
     end
+  end
+
+  defp all_by_selector(html, selector) do
+    html
+    |> Html.parse_fragment()
+    |> Html.all(selector)
+  end
+
+  defp filter_by_element_value(elements, value) do
+    Enum.filter(elements, &(value in element_values(&1)))
+  end
+
+  defp find_by_element_value_result(elements, value, potential_matches) do
+    elements
+    |> filter_by_element_value(value)
+    |> find_result(potential_matches)
+  end
+
+  defp find_result(elements, potential_matches) do
+    case elements do
+      [] -> {:not_found, potential_matches}
+      [found] -> {:found, found}
+      [_ | _] = found_many -> {:found_many, found_many}
+    end
+  end
+
+  defp element_values(element) do
+    case Html.element(element) do
+      {"select", _attrs, _children} -> selected_option_texts(element)
+      _ -> List.wrap(Html.attribute(element, "value"))
+    end
+  end
+
+  defp selected_option_texts(select) do
+    select
+    |> Html.selected_options()
+    |> Enum.map(&Html.element_text/1)
   end
 
   defp filter_by_position(elements, opts) do

--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -107,17 +107,17 @@ defmodule PhoenixTest.Query do
 
     elements_matched_selector
     |> filter_by_position(opts)
-    |> find_by_element_selected_result(selected, elements_matched_selector)
+    |> find_by_selected_option_text_result(selected, elements_matched_selector)
   end
 
   def find_by_label_and_selected(html, input_selectors, label, selected, opts \\ [])
       when is_binary(selected) and is_list(opts) do
     case find_by_label(html, input_selectors, label, opts) do
       {:found, element} ->
-        find_by_element_selected_result([element], selected, [element])
+        find_by_selected_option_text_result([element], selected, [element])
 
       {:not_found, :found_many_labels_with_inputs, _labels, elements} ->
-        find_by_element_selected_result(elements, selected, elements)
+        find_by_selected_option_text_result(elements, selected, elements)
 
       other ->
         other
@@ -601,8 +601,8 @@ defmodule PhoenixTest.Query do
     Enum.filter(elements, &(value in element_values(&1)))
   end
 
-  defp filter_by_element_selected(elements, selected) do
-    Enum.filter(elements, &(selected in element_selected_texts(&1)))
+  defp filter_by_selected_option_text(elements, selected) do
+    Enum.filter(elements, &(selected in selected_option_texts(&1)))
   end
 
   defp find_by_element_value_result(elements, value, potential_matches) do
@@ -611,9 +611,9 @@ defmodule PhoenixTest.Query do
     |> find_result(potential_matches)
   end
 
-  defp find_by_element_selected_result(elements, selected, potential_matches) do
+  defp find_by_selected_option_text_result(elements, selected, potential_matches) do
     elements
-    |> filter_by_element_selected(selected)
+    |> filter_by_selected_option_text(selected)
     |> find_result(potential_matches)
   end
 
@@ -629,17 +629,16 @@ defmodule PhoenixTest.Query do
     List.wrap(Html.attribute(element, "value"))
   end
 
-  defp element_selected_texts(element) do
+  defp selected_option_texts(element) do
     case Html.element(element) do
-      {"select", _attrs, _children} -> selected_option_texts(element)
-      _ -> []
-    end
-  end
+      {"select", _attrs, _children} ->
+        element
+        |> Html.selected_options()
+        |> Enum.map(&Html.element_text/1)
 
-  defp selected_option_texts(select) do
-    select
-    |> Html.selected_options()
-    |> Enum.map(&Html.element_text/1)
+      _ ->
+        []
+    end
   end
 
   defp filter_by_position(elements, opts) do

--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -102,6 +102,28 @@ defmodule PhoenixTest.Query do
     end
   end
 
+  def find_by_selected(html, selector, selected, opts \\ []) when is_binary(selected) and is_list(opts) do
+    elements_matched_selector = all_by_selector(html, selector)
+
+    elements_matched_selector
+    |> filter_by_position(opts)
+    |> find_by_element_selected_result(selected, elements_matched_selector)
+  end
+
+  def find_by_label_and_selected(html, input_selectors, label, selected, opts \\ [])
+      when is_binary(selected) and is_list(opts) do
+    case find_by_label(html, input_selectors, label, opts) do
+      {:found, element} ->
+        find_by_element_selected_result([element], selected, [element])
+
+      {:not_found, :found_many_labels_with_inputs, _labels, elements} ->
+        find_by_element_selected_result(elements, selected, elements)
+
+      other ->
+        other
+    end
+  end
+
   # Like `find/4`, but short-circuits after finding the first matching element.
   #
   # This is a performance improvement when you only need to confirm that at least one match exists.
@@ -579,9 +601,19 @@ defmodule PhoenixTest.Query do
     Enum.filter(elements, &(value in element_values(&1)))
   end
 
+  defp filter_by_element_selected(elements, selected) do
+    Enum.filter(elements, &(selected in element_selected_texts(&1)))
+  end
+
   defp find_by_element_value_result(elements, value, potential_matches) do
     elements
     |> filter_by_element_value(value)
+    |> find_result(potential_matches)
+  end
+
+  defp find_by_element_selected_result(elements, selected, potential_matches) do
+    elements
+    |> filter_by_element_selected(selected)
     |> find_result(potential_matches)
   end
 
@@ -594,9 +626,13 @@ defmodule PhoenixTest.Query do
   end
 
   defp element_values(element) do
+    List.wrap(Html.attribute(element, "value"))
+  end
+
+  defp element_selected_texts(element) do
     case Html.element(element) do
       {"select", _attrs, _children} -> selected_option_texts(element)
-      _ -> List.wrap(Html.attribute(element, "value"))
+      _ -> []
     end
   end
 

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -161,33 +161,33 @@ defmodule PhoenixTest.AssertionsTest do
     test "succeeds when select option was selected by an HTML selected attribute", %{conn: conn} do
       conn
       |> visit("/page/by_value")
-      |> assert_has("select", value: "Elf")
-      |> assert_has("select", label: "Race", value: "Elf")
+      |> assert_has("select", selected: "Elf")
+      |> assert_has("select", label: "Race", selected: "Elf")
     end
 
     test "succeeds when first select option is selected by browser default", %{conn: conn} do
       conn
       |> visit("/page/by_value")
-      |> assert_has("select", label: "Region", value: "Shire")
+      |> assert_has("select", label: "Region", selected: "Shire")
     end
 
-    test "does not match a select by an unselected option value", %{conn: conn} do
+    test "does not match a select by an unselected option", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
-      msg = ~r/with selector "select" and value "Human" with label "Race"/
+      msg = ~r/with selector "select" and selected "Human" with label "Race"/
 
       assert_raise AssertionError, msg, fn ->
-        assert_has(session, "select", label: "Race", value: "Human")
+        assert_has(session, "select", label: "Race", selected: "Human")
       end
     end
 
     test "does not match a select by the selected option value attribute", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
-      msg = ~r/with selector "select" and value "elf" with label "Race"/
+      msg = ~r/with selector "select" and selected "elf" with label "Race"/
 
       assert_raise AssertionError, msg, fn ->
-        assert_has(session, "select", label: "Race", value: "elf")
+        assert_has(session, "select", label: "Race", selected: "elf")
       end
     end
 
@@ -240,11 +240,15 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
-    test "raises if user provides :text and :value options", %{conn: conn} do
+    test "raises if user provides more than one content option", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
-      assert_raise ArgumentError, ~r/Cannot provide both :text and :value/, fn ->
+      assert_raise ArgumentError, ~r/Cannot provide more than one of :text, :value, and :selected/, fn ->
         assert_has(session, "div", text: "some text", value: "some value")
+      end
+
+      assert_raise ArgumentError, ~r/Cannot provide more than one of :text, :value, and :selected/, fn ->
+        assert_has(session, "select", selected: "Elf", value: "elf")
       end
     end
 
@@ -795,10 +799,10 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
-    test "can refute a select by unselected value", %{conn: conn} do
+    test "can refute a select by unselected option", %{conn: conn} do
       conn
       |> visit("/page/by_value")
-      |> refute_has("select", label: "Race", value: "Human")
+      |> refute_has("select", label: "Race", selected: "Human")
     end
 
     test "raises an error if value is found", %{conn: conn} do
@@ -811,13 +815,13 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
-    test "raises an error if select value is found", %{conn: conn} do
+    test "raises an error if selected option is found", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
-      msg = ~r/not to find any elements with selector "select" and value "Elf" with label "Race"/
+      msg = ~r/not to find any elements with selector "select" and selected "Elf" with label "Race"/
 
       assert_raise AssertionError, msg, fn ->
-        refute_has(session, "select", label: "Race", value: "Elf")
+        refute_has(session, "select", label: "Race", selected: "Elf")
       end
     end
 

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -253,12 +253,20 @@ defmodule PhoenixTest.AssertionsTest do
     test "raises if user provides more than one content option", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
-      assert_raise ArgumentError, ~r/Cannot provide more than one of :text, :value, and :selected/, fn ->
+      assert_raise ArgumentError, ~r/Cannot pass more than one of options :text, :value, :selected to assertions/, fn ->
         assert_has(session, "div", text: "some text", value: "some value")
       end
 
-      assert_raise ArgumentError, ~r/Cannot provide more than one of :text, :value, and :selected/, fn ->
+      assert_raise ArgumentError, ~r/Cannot pass more than one of options :text, :value, :selected to assertions/, fn ->
         assert_has(session, "select", selected: "Elf", value: "elf")
+      end
+    end
+
+    test "raises if user provides :label with :text", %{conn: conn} do
+      session = visit(conn, "/page/index")
+
+      assert_raise ArgumentError, ~r/Cannot provide :label with :text to assertions/, fn ->
+        assert_has(session, "h1", text: "Main page", label: "Title")
       end
     end
 
@@ -875,6 +883,14 @@ defmodule PhoenixTest.AssertionsTest do
 
       assert_raise ArgumentError, msg, fn ->
         refute_has(session, "h1", "Main page", text: "Other text", exact: true, count: 1)
+      end
+    end
+
+    test "raises if user provides :label with :text", %{conn: conn} do
+      session = visit(conn, "/page/index")
+
+      assert_raise ArgumentError, ~r/Cannot provide :label with :text to assertions/, fn ->
+        refute_has(session, "h1", "Main page", label: "Title")
       end
     end
   end

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -158,6 +158,39 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
+    test "succeeds when select option was selected by an HTML selected attribute", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> assert_has("select", value: "Elf")
+      |> assert_has("select", label: "Race", value: "Elf")
+    end
+
+    test "succeeds when first select option is selected by browser default", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> assert_has("select", label: "Region", value: "Shire")
+    end
+
+    test "does not match a select by an unselected option value", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      msg = ~r/with selector "select" and value "Human" with label "Race"/
+
+      assert_raise AssertionError, msg, fn ->
+        assert_has(session, "select", label: "Race", value: "Human")
+      end
+    end
+
+    test "does not match a select by the selected option value attribute", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      msg = ~r/with selector "select" and value "elf" with label "Race"/
+
+      assert_raise AssertionError, msg, fn ->
+        assert_has(session, "select", label: "Race", value: "elf")
+      end
+    end
+
     test "succeeds when selector matches either node with text, or any ancestor", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -762,6 +795,12 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
+    test "can refute a select by unselected value", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> refute_has("select", label: "Race", value: "Human")
+    end
+
     test "raises an error if value is found", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
@@ -769,6 +808,16 @@ defmodule PhoenixTest.AssertionsTest do
 
       assert_raise AssertionError, msg, fn ->
         refute_has(session, "input", value: "Frodo")
+      end
+    end
+
+    test "raises an error if select value is found", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      msg = ~r/not to find any elements with selector "select" and value "Elf" with label "Race"/
+
+      assert_raise AssertionError, msg, fn ->
+        refute_has(session, "select", label: "Race", value: "Elf")
       end
     end
 

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -181,6 +181,16 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
+    test "assert by label and selected raises an error if selected not found", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      assert_has(session, "select", label: "Race")
+
+      assert_raise AssertionError, ~r/selected "Human" with label "Race"/, fn ->
+        assert_has(session, "select", label: "Race", selected: "Human")
+      end
+    end
+
     test "does not match a select by the selected option value attribute", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
@@ -803,6 +813,16 @@ defmodule PhoenixTest.AssertionsTest do
       conn
       |> visit("/page/by_value")
       |> refute_has("select", label: "Race", selected: "Human")
+    end
+
+    test "refute by label and selected raises an error if selected found", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      refute_has(session, "select", label: "Race", selected: "Human")
+
+      assert_raise AssertionError, ~r/selected "Elf" with label "Race"/, fn ->
+        refute_has(session, "select", label: "Race", selected: "Elf")
+      end
     end
 
     test "raises an error if value is found", %{conn: conn} do

--- a/test/phoenix_test/html_test.exs
+++ b/test/phoenix_test/html_test.exs
@@ -98,4 +98,75 @@ defmodule PhoenixTest.HtmlTest do
       assert result == "Prefilled notes"
     end
   end
+
+  describe "selected_options" do
+    test "returns explicitly selected options" do
+      html = """
+      <select>
+        <option value="shire">Shire</option>
+        <option value="rivendell" selected>Rivendell</option>
+      </select>
+      """
+
+      result =
+        html
+        |> Html.parse_fragment()
+        |> Html.selected_options()
+        |> Enum.map(&Html.element_text/1)
+
+      assert result == ["Rivendell"]
+    end
+
+    test "falls back to the first option for single selects without an explicit selected option" do
+      html = """
+      <select>
+        <option value="shire">Shire</option>
+        <option value="rivendell">Rivendell</option>
+      </select>
+      """
+
+      result =
+        html
+        |> Html.parse_fragment()
+        |> Html.selected_options()
+        |> Enum.map(&Html.element_text/1)
+
+      assert result == ["Shire"]
+    end
+
+    test "returns all explicitly selected options for multi selects" do
+      html = """
+      <select multiple>
+        <option value="shire" selected>Shire</option>
+        <option value="rivendell">Rivendell</option>
+        <option value="moria" selected>Moria</option>
+      </select>
+      """
+
+      result =
+        html
+        |> Html.parse_fragment()
+        |> Html.selected_options()
+        |> Enum.map(&Html.element_text/1)
+
+      assert result == ["Shire", "Moria"]
+    end
+
+    test "returns no options for multi selects without an explicit selected option" do
+      html = """
+      <select multiple>
+        <option value="shire">Shire</option>
+        <option value="rivendell">Rivendell</option>
+      </select>
+      """
+
+      result =
+        html
+        |> Html.parse_fragment()
+        |> Html.selected_options()
+        |> Enum.map(&Html.element_text/1)
+
+      assert result == []
+    end
+  end
 end

--- a/test/support/web_app/page_view.ex
+++ b/test/support/web_app/page_view.ex
@@ -407,6 +407,19 @@ defmodule PhoenixTest.WebApp.PageView do
       <label>
         Kingdoms <input type="text" name="kingdom" value="Gondor" />
       </label>
+
+      <label for="race">Race</label>
+      <select id="race" name="race">
+        <option value="human">Human</option>
+        <option value="elf" selected>Elf</option>
+        <option value="dwarf">Dwarf</option>
+      </select>
+
+      <label for="region">Region</label>
+      <select id="region" name="region">
+        <option value="shire">Shire</option>
+        <option value="rivendell">Rivendell</option>
+      </select>
     </form>
     """
   end


### PR DESCRIPTION
Support `assert_has/3` and `refute_has/3` with `value:` for `select` elements by matching selected option text.

Implements #262.