### PR TITLE
Support async navigation in assert/refute_path

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1602,8 +1602,8 @@ defmodule PhoenixTest do
   defdelegate assert_download(session, file_name), to: Driver
 
   @doc """
-  Assert helper to verify current request path. Takes an optional `query_params`
-  map.
+  Assert helper to verify current request path. Takes optional `query_params`
+  and `timeout` options.
 
   > ### Note on Live Patch Implementation {: .info}
   >
@@ -1611,6 +1611,14 @@ defmodule PhoenixTest do
   could, therefore, be subject to intermittent failures. Please open an issue if
   you see intermittent failures when using `assert_path` with live patches so we
   can improve the implementation.
+
+  ## Options
+
+  - `query_params`: map of query params to match exactly
+
+  - `timeout`: currently only works with LiveViews. If you pass a positive
+  `timeout`, PhoenixTest will wait for async navigation and patch updates before
+  asserting on the current path. (defaults to `0`)
 
   ## Examples
 
@@ -1630,13 +1638,20 @@ defmodule PhoenixTest do
   |> visit("/users")
   |> click_link("Any User")
   |> assert_path("/users/*/profile")
+
+  # assert the path after an async patch or navigation
+  conn
+  |> visit("/live/async_page")
+  |> click_button("Async patch!")
+  |> assert_path("/live/async_page", query_params: %{patched: "true"}, timeout: 250)
   ```
   """
   @doc group: "Assertions"
   defdelegate assert_path(session, path), to: Driver
 
   @doc """
-  Same as `assert_path/2` but takes an optional `query_params` map.
+  Same as `assert_path/2` but takes optional `query_params` and `timeout`
+  options.
   """
   @doc group: "Assertions"
   defdelegate assert_path(session, path, opts), to: Driver
@@ -1651,6 +1666,14 @@ defmodule PhoenixTest do
   could, therefore, be subject to intermittent failures. Please open an issue if
   you see intermittent failures when using `refute_path` with live patches so we
   can improve the implementation.
+
+  ## Options
+
+  - `query_params`: map of query params to refute
+
+  - `timeout`: currently only works with LiveViews. If you pass a positive
+  `timeout`, PhoenixTest will wait for async navigation and patch updates before
+  refuting the current path. (defaults to `0`)
 
   ## Examples
 
@@ -1670,8 +1693,8 @@ defmodule PhoenixTest do
   defdelegate refute_path(session, path), to: Driver
 
   @doc """
-  Same as `refute_path/2` but takes an optional `query_params` for more specific
-  refutation.
+  Same as `refute_path/2` but takes optional `query_params` and `timeout`
+  options for more specific refutation.
   """
   @doc group: "Assertions"
   defdelegate refute_path(session, path, opts), to: Driver

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -270,29 +270,33 @@ defmodule PhoenixTest.Assertions do
     session
   end
 
-  def assert_path(session, path, opts \\ [])
-
-  def assert_path(session, path, []) do
+  def assert_path(session, path, opts \\ []) do
     session = set_operation(session, :assert_path, "")
     uri = URI.parse(PhoenixTest.Driver.current_path(session))
+    params = opts[:query_params] && Utils.stringify_keys_and_values(opts[:query_params])
 
-    if path_matches?(path, uri.path) do
-      assert true
-    else
-      msg = """
-      Expected path to be #{inspect(path)} but got #{inspect(uri.path)}
-      """
+    cond do
+      not path_matches?(path, uri.path) ->
+        msg = """
+        Expected path to be #{inspect(path)} but got #{inspect(uri.path)}
+        """
 
-      raise AssertionError, msg
+        raise AssertionError, msg
+
+      is_nil(params) or query_params_match?(session, params) ->
+        assert true
+
+      true ->
+        params_string = Plug.Conn.Query.encode(params)
+
+        msg = """
+        Expected query params to be #{inspect(params_string)} but got #{inspect(uri.query)}
+        """
+
+        raise AssertionError, msg
     end
 
     session
-  end
-
-  def assert_path(session, path, query_params: params) do
-    session
-    |> assert_path(path, [])
-    |> assert_query_params(params)
   end
 
   defp path_matches?(path, path), do: true
@@ -317,73 +321,40 @@ defmodule PhoenixTest.Assertions do
   def uri_parts_match?(part, part), do: true
   def uri_parts_match?(_a, _b), do: false
 
-  defp assert_query_params(session, params) do
-    params = Utils.stringify_keys_and_values(params)
-
+  defp query_params_match?(session, expected_params) do
     uri = URI.parse(PhoenixTest.Driver.current_path(session))
-    query_params = uri.query && Plug.Conn.Query.decode(uri.query)
+    params = uri.query && Plug.Conn.Query.decode(uri.query)
+
+    params == expected_params or (is_nil(params) and expected_params == %{})
+  end
+
+  def refute_path(session, path, opts \\ []) do
+    session = set_operation(session, :refute_path, "")
+    uri = URI.parse(PhoenixTest.Driver.current_path(session))
+    params = opts[:query_params] && Utils.stringify_keys_and_values(opts[:query_params])
 
     cond do
-      query_params == params ->
-        assert true
+      not path_matches?(path, uri.path) ->
+        refute false
 
-      is_nil(query_params) && params == %{} ->
-        assert true
-
-      true ->
-        params_string = Plug.Conn.Query.encode(params)
-
+      is_nil(params) ->
         msg = """
-        Expected query params to be #{inspect(params_string)} but got #{inspect(uri.query)}
+        Expected path not to be #{inspect(path)}
         """
 
         raise AssertionError, msg
-    end
 
-    session
-  end
+      query_params_match?(session, params) ->
+        params_string = URI.encode_query(params)
 
-  def refute_path(session, path, opts \\ [])
+        msg = """
+        Expected query params not to be #{inspect(params_string)}
+        """
 
-  def refute_path(session, path, []) do
-    session = set_operation(session, :refute_path, "")
-    uri = URI.parse(PhoenixTest.Driver.current_path(session))
+        raise AssertionError, msg
 
-    if uri.path == path do
-      msg = """
-      Expected path not to be #{inspect(path)}
-      """
-
-      raise AssertionError, msg
-    else
-      refute false
-    end
-
-    session
-  end
-
-  def refute_path(session, path, query_params: params) do
-    session = set_operation(session, :refute_path, "")
-
-    refute_query_params(session, params) || refute_path(session, path, [])
-  end
-
-  defp refute_query_params(session, params) do
-    params = Utils.stringify_keys_and_values(params)
-
-    uri = URI.parse(PhoenixTest.Driver.current_path(session))
-    query_params = uri.query && URI.decode_query(uri.query)
-
-    if query_params == params do
-      params_string = URI.encode_query(params)
-
-      msg = """
-      Expected query params not to be #{inspect(params_string)}
-      """
-
-      raise AssertionError, msg
-    else
-      refute false
+      true ->
+        refute false
     end
 
     session

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -270,7 +270,9 @@ defmodule PhoenixTest.Assertions do
     session
   end
 
-  def assert_path(session, path) do
+  def assert_path(session, path, opts \\ [])
+
+  def assert_path(session, path, []) do
     session = set_operation(session, :assert_path, "")
     uri = URI.parse(PhoenixTest.Driver.current_path(session))
 
@@ -287,11 +289,9 @@ defmodule PhoenixTest.Assertions do
     session
   end
 
-  def assert_path(session, path, opts) do
-    params = Keyword.get(opts, :query_params)
-
+  def assert_path(session, path, query_params: params) do
     session
-    |> assert_path(path)
+    |> assert_path(path, [])
     |> assert_query_params(params)
   end
 
@@ -343,7 +343,9 @@ defmodule PhoenixTest.Assertions do
     session
   end
 
-  def refute_path(session, path) do
+  def refute_path(session, path, opts \\ [])
+
+  def refute_path(session, path, []) do
     session = set_operation(session, :refute_path, "")
     uri = URI.parse(PhoenixTest.Driver.current_path(session))
 
@@ -360,11 +362,10 @@ defmodule PhoenixTest.Assertions do
     session
   end
 
-  def refute_path(session, path, opts) do
+  def refute_path(session, path, query_params: params) do
     session = set_operation(session, :refute_path, "")
-    params = Keyword.get(opts, :query_params)
 
-    refute_query_params(session, params) || refute_path(session, path)
+    refute_query_params(session, params) || refute_path(session, path, [])
   end
 
   defp refute_query_params(session, params) do

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -642,6 +642,34 @@ defmodule PhoenixTest.Live do
     end)
   end
 
+  def assert_path(session, path) do
+    assert_path(session, path, [])
+  end
+
+  def assert_path(session, path, opts) when is_list(opts) do
+    {timeout, opts} = Keyword.pop(opts, :timeout, 0)
+
+    LiveViewTimeout.with_timeout(session, timeout, fn session ->
+      session
+      |> maybe_sync_current_path(timeout)
+      |> Assertions.assert_path(path, opts)
+    end)
+  end
+
+  def refute_path(session, path) do
+    refute_path(session, path, [])
+  end
+
+  def refute_path(session, path, opts) when is_list(opts) do
+    {timeout, opts} = Keyword.pop(opts, :timeout, 0)
+
+    LiveViewTimeout.with_timeout(session, timeout, fn session ->
+      session
+      |> maybe_sync_current_path(timeout)
+      |> Assertions.refute_path(path, opts)
+    end)
+  end
+
   def handle_redirect(session, redirect_tuple) do
     maybe_redirect({:error, redirect_tuple}, session)
   end
@@ -705,6 +733,12 @@ defmodule PhoenixTest.Live do
     end
   end
 
+  defp maybe_sync_current_path(%__MODULE__{} = session, timeout) when timeout > 0 do
+    maybe_put_patch_path(session)
+  end
+
+  defp maybe_sync_current_path(session, _timeout), do: session
+
   defp fetch_patch_path(view) do
     assert_patch(view, 0)
   rescue
@@ -760,8 +794,8 @@ defimpl PhoenixTest.Driver, for: PhoenixTest.Live do
   defdelegate refute_has(session, selector), to: Assertions
   defdelegate refute_has(session, selector, opts), to: Live
   defdelegate assert_download(session, file_name), to: Assertions
-  defdelegate assert_path(session, path), to: Assertions
-  defdelegate assert_path(session, path, opts), to: Assertions
-  defdelegate refute_path(session, path), to: Assertions
-  defdelegate refute_path(session, path, opts), to: Assertions
+  defdelegate assert_path(session, path), to: Live
+  defdelegate assert_path(session, path, opts), to: Live
+  defdelegate refute_path(session, path), to: Live
+  defdelegate refute_path(session, path, opts), to: Live
 end

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -1575,6 +1575,40 @@ defmodule PhoenixTest.LiveTest do
     end
   end
 
+  describe "assert_path/3 with timeout" do
+    test "defaults to timeout 0", %{conn: conn} do
+      assert_raise AssertionError, fn ->
+        conn
+        |> visit("/live/async_page")
+        |> click_button("Async patch!")
+        |> assert_path("/live/async_page", query_params: %{patched: "true"})
+      end
+    end
+
+    test "timeout handles handle_info patches", %{conn: conn} do
+      conn
+      |> visit("/live/async_page")
+      |> click_button("Async patch!")
+      |> assert_path("/live/async_page", query_params: %{patched: "true"}, timeout: 250)
+    end
+
+    test "timeout handles async navigates", %{conn: conn} do
+      conn
+      |> visit("/live/async_page")
+      |> click_button("Async navigate!")
+      |> assert_path("/live/page_2", timeout: 250)
+    end
+  end
+
+  describe "refute_path/3 with timeout" do
+    test "timeout handles async navigates", %{conn: conn} do
+      conn
+      |> visit("/live/async_page")
+      |> click_button("Async navigate!")
+      |> refute_path("/live/async_page", timeout: 250)
+    end
+  end
+
   describe "conditionally rendered form fields" do
     test "submitting after switching versions only includes the visible field", %{conn: conn} do
       conn

--- a/test/support/web_app/async_page_live.ex
+++ b/test/support/web_app/async_page_live.ex
@@ -12,6 +12,10 @@ defmodule PhoenixTest.WebApp.AsyncPageLive do
      end)}
   end
 
+  def handle_params(_params, _uri, socket) do
+    {:noreply, socket}
+  end
+
   def render(assigns) do
     ~H"""
     <.async_result :let={title} assign={@title}>
@@ -30,6 +34,10 @@ defmodule PhoenixTest.WebApp.AsyncPageLive do
 
     <button phx-click="async-navigate">
       Async navigate!
+    </button>
+
+    <button phx-click="async-patch">
+      Async patch!
     </button>
 
     <button phx-click="async-navigate-to-async">
@@ -64,6 +72,11 @@ defmodule PhoenixTest.WebApp.AsyncPageLive do
        Process.sleep(100)
        :ok
      end)}
+  end
+
+  def handle_event("async-patch", _, socket) do
+    Process.send_after(self(), :async_patch, 100)
+    {:noreply, socket}
   end
 
   def handle_event("async-navigate-to-async", _, socket) do
@@ -101,5 +114,9 @@ defmodule PhoenixTest.WebApp.AsyncPageLive do
 
   def handle_info(:change_h2, socket) do
     {:noreply, assign(socket, :h2, "I've been changed!")}
+  end
+
+  def handle_info(:async_patch, socket) do
+    {:noreply, push_patch(socket, to: "/live/async_page?patched=true")}
   end
 end


### PR DESCRIPTION
Close #209 

Add `timeout` option to `assert_path` and `refute_path`, so they can react to async navigation.