### PR TITLE
Add :checked option to assert_has/3 and refute_has/3

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -1343,11 +1343,12 @@ defmodule PhoenixTest do
   than one matching element is found (unless `:count` option is used).
 
   You can assert an element's contents using `:text`, assert a field's value
-  using `:value` (with an optional `:label`), or assert a `select` element's
-  selected option text using `:selected`.
+  using `:value` (with an optional `:label`), assert a `select` element's
+  selected option text using `:selected`, or assert a checkbox/radio's checked
+  state using `:checked` (with an optional `:label`).
 
-  NOTE that you cannot specify more than one of `:text`, `:value`, and
-  `:selected` as options.
+  NOTE that you cannot specify more than one of `:text`, `:value`, `:selected`,
+  and `:checked` as options.
 
   The `:text`, `:value`, or `:selected` option can be a binary or anything for which
   there is an implementation of the `Phoenix.HTML.Safe` protocol. PhoenixTest
@@ -1362,7 +1363,11 @@ defmodule PhoenixTest do
 
   - `selected`: the selected option's text to look for on a `select`.
 
-  - `label`: the label associated to the form field with `value` or `selected`
+  - `checked`: whether the radio or checkbox form field is checked.
+    Pass `true` to look for a checked field, or `false` to look for an
+    unchecked field.
+
+  - `label`: the label associated to the form field with `value`, `selected`, or `checked`
 
   - `exact`: by default `assert_has/3` will perform a substring match (e.g. `a
   =~ b`). That makes it easier to assert text within HTML elements that also
@@ -1400,6 +1405,12 @@ defmodule PhoenixTest do
 
   # assert there's a select labeled by "Race" with the "Elf" option selected
   assert_has(session, "select", selected: "Elf", label: "Race")
+
+  # assert there's a checked checkbox or radio button labeled by "Frodo"
+  assert_has(session, "input", checked: true, label: "Frodo")
+
+  # assert there's an unchecked checkbox or radio button labeled by "Sam"
+  assert_has(session, "input", checked: false, label: "Sam")
 
   # assert there are two elements with class "posts"
   assert_has(session, ".posts", count: 2)
@@ -1475,8 +1486,8 @@ defmodule PhoenixTest do
 
   It'll raise an error if any elements that match selector and options.
 
-  NOTE that you cannot specify more than one of `:text`, `:value`, and
-  `:selected` as options.
+  NOTE that you cannot specify more than one of `:text`, `:value`, `:selected`,
+  and `:checked` as options.
 
   The `:text`, `:value`, or `:selected` option can be a binary or anything for which
   there is an implementation of the `Phoenix.HTML.Safe` protocol. PhoenixTest
@@ -1491,7 +1502,11 @@ defmodule PhoenixTest do
 
   - `selected`: the selected option's text to look for on a `select`.
 
-  - `label`: the label associated to the form field with `value` or `selected`
+  - `checked`: whether the checkbox or radio button form field is checked.
+    Pass `true` to look for a checked field or `false` to look for an
+    unchecked field.
+
+  - `label`: the label associated to the form field with `value`, `selected`, or `checked`
 
   - `exact`: by default `refute_has/3` will perform a substring match (e.g. `a
   =~ b`). That makes it easier to refute text within HTML elements that also
@@ -1527,6 +1542,12 @@ defmodule PhoenixTest do
 
   # refute there's a select labeled by "Race" with the "Human" option selected
   refute_has(session, "select", selected: "Human", label: "Race")
+
+  # refute there's a checked checkbox or radio button labeled by "Sam"
+  refute_has(session, "input", checked: true, label: "Sam")
+
+  # refute there's an unchecked checkbox or radio button labeled by "Frodo"
+  refute_has(session, "input", checked: false, label: "Frodo")
 
   # refute there are two elements with class "posts" (less or more will not raise)
   refute_has(session, ".posts", count: 2)

--- a/lib/phoenix_test/assertions.ex
+++ b/lib/phoenix_test/assertions.ex
@@ -13,6 +13,7 @@ defmodule PhoenixTest.Assertions do
     @moduledoc false
     defstruct [
       :at,
+      :checked,
       :count,
       :exact,
       :label,
@@ -23,6 +24,13 @@ defmodule PhoenixTest.Assertions do
 
     def parse(opts) when is_list(opts) do
       at = Keyword.get(opts, :at, :any)
+
+      checked =
+        case Keyword.get(opts, :checked, :no_checked) do
+          valid when is_boolean(valid) or valid == :no_checked -> valid
+          other -> raise ArgumentError, "Expected :checked to be true or false, got #{inspect(other)}"
+        end
+
       count = Keyword.get(opts, :count, :any)
       exact = Keyword.get(opts, :exact, false)
       label = Keyword.get(opts, :label, :no_label)
@@ -32,6 +40,7 @@ defmodule PhoenixTest.Assertions do
 
       %__MODULE__{
         at: at,
+        checked: checked,
         count: count,
         exact: exact,
         label: label,
@@ -44,6 +53,7 @@ defmodule PhoenixTest.Assertions do
     def to_list(%__MODULE__{} = opts) do
       [
         at: opts.at,
+        checked: opts.checked,
         count: opts.count,
         exact: opts.exact,
         label: opts.label,
@@ -365,6 +375,7 @@ defmodule PhoenixTest.Assertions do
     |> maybe_append_text(opts.text)
     |> maybe_append_value(opts.value)
     |> maybe_append_selected(opts.selected)
+    |> maybe_append_checked(opts.checked)
     |> maybe_append_label(opts.label)
     |> append_found(found)
   end
@@ -374,6 +385,7 @@ defmodule PhoenixTest.Assertions do
     |> maybe_append_text(opts.text)
     |> maybe_append_value(opts.value)
     |> maybe_append_selected(opts.selected)
+    |> maybe_append_checked(opts.checked)
     |> maybe_append_label(opts.label)
     |> maybe_append_position(opts.at)
     |> append_found_other_matches(selector, other_matches)
@@ -384,6 +396,7 @@ defmodule PhoenixTest.Assertions do
     |> maybe_append_text(opts.text)
     |> maybe_append_value(opts.value)
     |> maybe_append_selected(opts.selected)
+    |> maybe_append_checked(opts.checked)
     |> maybe_append_label(opts.label)
     |> maybe_append_position(opts.at)
     |> append_found(found)
@@ -416,6 +429,9 @@ defmodule PhoenixTest.Assertions do
   defp maybe_append_selected(msg, :no_selected), do: msg
   defp maybe_append_selected(msg, selected), do: msg <> " and selected #{inspect(selected)}"
 
+  defp maybe_append_checked(msg, :no_checked), do: msg
+  defp maybe_append_checked(msg, checked), do: msg <> " and checked #{inspect(checked)}"
+
   defp maybe_append_label(msg, :no_label), do: msg
   defp maybe_append_label(msg, label), do: msg <> " with label #{inspect(label)}"
 
@@ -425,8 +441,8 @@ defmodule PhoenixTest.Assertions do
   defp finder_fun(selector, %Opts{} = opts, operation) do
     content =
       opts
-      |> Map.take(~w(text value selected)a)
-      |> Enum.reject(&(&1 in [text: :no_text, value: :no_value, selected: :no_selected]))
+      |> Map.take(~w(text value selected checked)a)
+      |> Enum.reject(&(&1 in [text: :no_text, value: :no_value, selected: :no_selected, checked: :no_checked]))
 
     case {content, opts, operation} do
       {[], %Opts{label: :no_label}, _} ->
@@ -449,6 +465,14 @@ defmodule PhoenixTest.Assertions do
       {[selected: selected], %Opts{label: label}, _} when is_binary(label) ->
         &Query.find_by_label_and_selected(&1, selector, label, ensure_binary(selected), Opts.to_list(opts))
 
+      {[checked: checked], %Opts{label: :no_label}, _} ->
+        selector = maybe_append_checked_selector(selector, checked)
+        &Query.find(&1, selector, Opts.to_list(opts))
+
+      {[checked: checked], %Opts{label: label}, _} when is_binary(label) ->
+        selector = maybe_append_checked_selector(selector, checked)
+        &Query.find_by_label(&1, selector, label, Opts.to_list(opts))
+
       {[text: text], %Opts{label: :no_label, count: :any, at: :any}, :assert_has} ->
         &Query.find_first(&1, selector, ensure_binary(text), Opts.to_list(opts))
 
@@ -459,9 +483,12 @@ defmodule PhoenixTest.Assertions do
         raise ArgumentError, "Cannot provide :label with :text to assertions"
 
       _ ->
-        raise ArgumentError, "Cannot pass more than one of options :text, :value, :selected to assertions"
+        raise ArgumentError, "Cannot pass more than one of options :text, :value, :selected, :checked to assertions"
     end
   end
+
+  defp maybe_append_checked_selector(selector, true), do: selector <> ":checked"
+  defp maybe_append_checked_selector(selector, false), do: selector <> ":not(:checked)"
 
   defp ensure_binary(value) when is_binary(value), do: value
 

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -201,6 +201,27 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
+    test "succeeds when asserting checked state + count", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> assert_has(".user", count: 3)
+      |> assert_has(".user", checked: true, count: 2)
+      |> assert_has(".user", checked: false, count: 1)
+    end
+
+    test "succeeds when searching by checked state and implicit label", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> assert_has(".user", checked: true, label: "Frodo")
+      |> assert_has(".user", checked: false, label: "Sam")
+    end
+
+    test "succeeds when searching by checked state and explicit label", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> assert_has(".user", checked: true, label: "Merry")
+    end
+
     test "succeeds when selector matches either node with text, or any ancestor", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -250,15 +271,45 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
+    test "raises an error if checked state (with label) cannot be found", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      msg = ~r/with selector "\.user" and checked true with label "Sam"/
+
+      assert_raise AssertionError, msg, fn ->
+        assert_has(session, ".user", checked: true, label: "Sam")
+      end
+    end
+
+    test "raises if user provides :text and :checked options", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      assert_raise ArgumentError, ~r/Cannot pass more than one of options :text, :value, :selected, :checked/, fn ->
+        assert_has(session, ".user", text: "Frodo", checked: true)
+      end
+    end
+
+    test "raises if user provides non-boolean :checked option", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      assert_raise ArgumentError, ~r/Expected :checked to be true or false, got "yes"/, fn ->
+        assert_has(session, ".user", checked: "yes")
+      end
+    end
+
     test "raises if user provides more than one content option", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
-      assert_raise ArgumentError, ~r/Cannot pass more than one of options :text, :value, :selected to assertions/, fn ->
+      assert_raise ArgumentError, ~r/Cannot pass more than one of options :text, :value, :selected, :checked/, fn ->
         assert_has(session, "div", text: "some text", value: "some value")
       end
 
-      assert_raise ArgumentError, ~r/Cannot pass more than one of options :text, :value, :selected to assertions/, fn ->
+      assert_raise ArgumentError, ~r/Cannot pass more than one of options :text, :value, :selected, :checked/, fn ->
         assert_has(session, "select", selected: "Elf", value: "elf")
+      end
+
+      assert_raise ArgumentError, ~r/Cannot pass more than one of options :text, :value, :selected, :checked/, fn ->
+        assert_has(session, "input", checked: true, text: "Frodo")
       end
     end
 
@@ -833,6 +884,21 @@ defmodule PhoenixTest.AssertionsTest do
       end
     end
 
+    test "can refute by checked state + count", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> refute_has(".user", checked: true, count: 1)
+      |> refute_has(".user", checked: false, count: 2)
+    end
+
+    test "can refute by checked state and label", %{conn: conn} do
+      conn
+      |> visit("/page/by_value")
+      |> refute_has(".user", checked: true, label: "Sam")
+      |> refute_has(".user", checked: false, label: "Frodo")
+      |> refute_has(".user", checked: false, label: "Merry")
+    end
+
     test "raises an error if value is found", %{conn: conn} do
       session = visit(conn, "/page/by_value")
 
@@ -870,6 +936,16 @@ defmodule PhoenixTest.AssertionsTest do
 
       assert_raise AssertionError, msg, fn ->
         refute_has(session, "input", label: "Hobbit", value: "Frodo")
+      end
+    end
+
+    test "raises an error if checked state and label are found", %{conn: conn} do
+      session = visit(conn, "/page/by_value")
+
+      msg = ~r/with selector "\.user" and checked true with label "Frodo"/
+
+      assert_raise AssertionError, msg, fn ->
+        refute_has(session, ".user", checked: true, label: "Frodo")
       end
     end
 

--- a/test/phoenix_test/assertions_test.exs
+++ b/test/phoenix_test/assertions_test.exs
@@ -222,6 +222,12 @@ defmodule PhoenixTest.AssertionsTest do
       |> assert_has(".user", checked: true, label: "Merry")
     end
 
+    test "succeeds when searching by checked state and radio button label", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> assert_has("input[type='radio']", checked: true, label: "Mail Choice")
+    end
+
     test "succeeds when selector matches either node with text, or any ancestor", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/support/web_app/page_view.ex
+++ b/test/support/web_app/page_view.ex
@@ -420,6 +420,18 @@ defmodule PhoenixTest.WebApp.PageView do
         <option value="shire">Shire</option>
         <option value="rivendell">Rivendell</option>
       </select>
+
+      <label>
+        Frodo <input class="user" type="checkbox" name="users[]" value="frodo" checked />
+      </label>
+      <label>
+        Sam <input class="user" type="checkbox" name="users[]" value="sam" />
+      </label>
+
+      <label for="merry-checkbox">
+        Merry
+      </label>
+      <input id="merry-checkbox" class="user" type="checkbox" name="users[]" value="merry" checked />
     </form>
     """
   end


### PR DESCRIPTION
Adds support for assertions like:

```elixir
assert_has(session, ".user", checked: true, label: "Frodo")
assert_has(session, ".user", checked: false, label: "Frodo")
```

Resolves #213