### PR TITLE
Fix: Omit hidden input before checkbox group

### DIFF
--- a/lib/phoenix_test/element/form.ex
+++ b/lib/phoenix_test/element/form.ex
@@ -69,7 +69,7 @@ defmodule PhoenixTest.Element.Form do
 
   def has_action?(form), do: Utils.present?(form.action)
 
-  @enabled_controls "input:not([disabled])[name], textarea:not([disabled])[name], select:not([disabled])[name]"
+  @enabled_controls ":is(input, textarea, select):not([disabled])[name]"
 
   defp form_data(form) do
     form

--- a/lib/phoenix_test/element/form.ex
+++ b/lib/phoenix_test/element/form.ex
@@ -69,70 +69,58 @@ defmodule PhoenixTest.Element.Form do
 
   def has_action?(form), do: Utils.present?(form.action)
 
-  @simple_value_types ~w(
-    date
-    datetime-local
-    email
-    month
-    number
-    password
-    range
-    search
-    tel
-    text
-    time
-    url
-    week
-  )
-
-  @hidden_inputs "input[type='hidden']"
-  @checked_radio_buttons "input:not([disabled])[type='radio'][value]:checked"
-  @checked_checkboxes "input:not([disabled])[type='checkbox'][value]:checked"
-  @pre_filled_default_text_inputs "input:not([disabled]):not([type])[value]"
-
-  @pre_filled_simple_value_inputs Enum.map_join(
-                                    @simple_value_types,
-                                    ",",
-                                    &"input:not([disabled])[type='#{&1}'][value]"
-                                  )
+  @enabled_controls "input:not([disabled])[name], textarea:not([disabled])[name], select:not([disabled])[name]"
 
   defp form_data(form) do
-    FormData.new()
-    |> FormData.add_data(form_data(@hidden_inputs, form))
-    |> FormData.add_data(form_data(@checked_radio_buttons, form))
-    |> FormData.add_data(form_data(@checked_checkboxes, form))
-    |> FormData.add_data(form_data(@pre_filled_simple_value_inputs, form))
-    |> FormData.add_data(form_data(@pre_filled_default_text_inputs, form))
-    |> FormData.add_data(form_data_textarea(form))
-    |> FormData.add_data(form_data_select(form))
-  end
-
-  defp form_data(selector, form) do
     form
-    |> Html.all(selector)
-    |> Enum.map(&to_form_field/1)
-  end
-
-  defp form_data_textarea(form) do
-    form
-    |> Html.all("textarea:not([disabled])")
-    |> Enum.map(&to_form_field/1)
-  end
-
-  defp form_data_select(form) do
-    form
-    |> Html.all("select:not([disabled])")
-    |> Enum.flat_map(fn select ->
-      select
-      |> Html.selected_options()
-      |> Enum.map(&to_form_field(select, &1))
-    end)
+    |> Html.all(@enabled_controls)
+    |> Enum.reduce(FormData.new(), &append_form_field(&2, Html.tag(&1), &1))
   end
 
   def put_button_data(form, nil), do: form
 
   def put_button_data(form, %Button{} = button) do
     Map.update!(form, :form_data, &FormData.add_data(&1, button))
+  end
+
+  defp append_form_field(form_data, "input", element) do
+    name = Html.attribute(element, "name")
+    value = Html.attribute(element, "value")
+    type = Html.attribute(element, "type")
+
+    cond do
+      !value ->
+        form_data
+
+      type == "hidden" ->
+        FormData.add_data(form_data, name, value)
+
+      type in ~w(radio checkbox) and Html.attribute(element, "checked") ->
+        FormData.add_data(form_data, name, value)
+
+      type in ~w(radio checkbox) ->
+        form_data
+
+      true ->
+        FormData.add_data(form_data, name, value)
+    end
+  end
+
+  defp append_form_field(form_data, "textarea", element) do
+    FormData.add_data(form_data, to_form_field(element))
+  end
+
+  defp append_form_field(form_data, "select", select) do
+    values =
+      select
+      |> Html.selected_options()
+      |> Enum.map(&element_value/1)
+
+    case values do
+      [] -> form_data
+      [value] -> FormData.add_data(form_data, Html.attribute(select, "name"), value)
+      many -> FormData.add_data(form_data, Html.attribute(select, "name"), many)
+    end
   end
 
   defp to_form_field(element) do

--- a/lib/phoenix_test/form_data.ex
+++ b/lib/phoenix_test/form_data.ex
@@ -5,7 +5,7 @@ defmodule PhoenixTest.FormData do
   alias PhoenixTest.Element.Field
   alias PhoenixTest.Element.Select
 
-  defstruct data: %{}, order: []
+  defstruct data: []
 
   def new, do: %__MODULE__{}
 
@@ -35,132 +35,106 @@ defmodule PhoenixTest.FormData do
 
   def add_data(%__MODULE__{} = form_data, name, value) do
     if allows_multiple_values?(name) do
-      new_data =
-        Map.update(form_data.data, name, List.wrap(value), fn existing_value ->
-          if value in existing_value do
-            existing_value
-          else
-            existing_value ++ List.wrap(value)
-          end
-        end)
+      existing_values = values_for_name(form_data.data, name)
 
-      %__MODULE__{form_data | data: new_data, order: append_order(form_data.order, name)}
+      new_entries =
+        value
+        |> List.wrap()
+        |> Enum.reject(&(&1 in existing_values))
+        |> Enum.map(&{name, &1})
+
+      %__MODULE__{form_data | data: form_data.data ++ new_entries}
     else
-      %__MODULE__{
-        form_data
-        | data: Map.put(form_data.data, name, value),
-          order: append_order(form_data.order, name)
-      }
+      put_data(form_data, name, value)
     end
   end
 
-  def merge(%__MODULE__{} = fd1, %__MODULE__{} = fd2) do
-    data =
-      Map.merge(fd1.data, fd2.data, fn k, v1, v2 ->
-        if allows_multiple_values?(k) do
-          Enum.uniq(v1 ++ v2)
-        else
-          v2
-        end
-      end)
-
-    %__MODULE__{data: data, order: merge_orders(fd1, fd2)}
+  def merge(%__MODULE__{} = form_data1, %__MODULE__{} = form_data2) do
+    form_data2
+    |> field_names()
+    |> Enum.reduce(form_data1, fn name, acc ->
+      if allows_multiple_values?(name) do
+        add_data(acc, name, get_data(form_data2, name))
+      else
+        put_data(acc, name, get_data(form_data2, name))
+      end
+    end)
   end
 
-  def override(%__MODULE__{} = fd1, %__MODULE__{} = fd2) do
-    %__MODULE__{
-      data: Map.merge(fd1.data, fd2.data),
-      order: merge_orders(fd1, fd2)
-    }
+  def override(%__MODULE__{} = form_data1, %__MODULE__{} = form_data2) do
+    form_data2
+    |> field_names()
+    |> Enum.reduce(form_data1, fn name, acc ->
+      put_data(acc, name, get_data(form_data2, name))
+    end)
   end
 
   def get_data(%__MODULE__{data: data}, name) do
-    Map.get(data, name)
+    values = values_for_name(data, name)
+
+    cond do
+      values == [] -> nil
+      allows_multiple_values?(name) or length(values) > 1 -> values
+      true -> hd(values)
+    end
   end
 
   def put_data(%__MODULE__{} = form_data, name, value) when is_nil(name) or is_nil(value), do: form_data
 
   def put_data(%__MODULE__{} = form_data, name, value) do
-    %__MODULE__{
-      form_data
-      | data: Map.put(form_data.data, name, value),
-        order: append_order(form_data.order, name)
-    }
+    new_entries =
+      value
+      |> List.wrap()
+      |> Enum.reject(&is_nil/1)
+      |> Enum.map(&{name, &1})
+
+    %__MODULE__{form_data | data: replace_entries(form_data.data, name, new_entries)}
   end
 
   defp allows_multiple_values?(field_name), do: String.ends_with?(field_name, "[]")
 
-  def filter(%__MODULE__{} = form_data, fun) do
-    data =
-      form_data
-      |> ordered_names()
-      |> Enum.reduce(%{}, fn name, acc ->
-        value = Map.get(form_data.data, name)
-
-        if keep_data?(fun, name, value) do
-          Map.put(acc, name, value)
-        else
-          acc
-        end
-      end)
-
-    order =
-      form_data
-      |> ordered_names()
-      |> Enum.filter(&Map.has_key?(data, &1))
-
-    %__MODULE__{data: data, order: order}
+  def filter(%__MODULE__{data: data}, fun) do
+    %__MODULE__{
+      data:
+        Enum.filter(data, fn {name, value} ->
+          fun.(%{name: name, value: value})
+        end)
+    }
   end
 
   def empty?(%__MODULE__{data: data}) do
     Enum.empty?(data)
   end
 
-  def has_data?(%__MODULE__{data: data}, name, value) do
-    field_data = Map.get(data, name, [])
+  def has_data?(%__MODULE__{} = form_data, name, value) do
+    field_data = get_data(form_data, name)
 
     value == field_data or value in List.wrap(field_data)
   end
 
   def field_names(%__MODULE__{data: data}) do
-    Map.keys(data)
+    data
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.uniq()
   end
 
-  def to_list(%__MODULE__{} = form_data) do
-    form_data
-    |> ordered_names()
-    |> Enum.flat_map(fn name ->
-      case Map.fetch!(form_data.data, name) do
-        values when is_list(values) ->
-          Enum.map(values, &{name, &1})
+  def to_list(%__MODULE__{data: data}), do: data
 
-        value ->
-          [{name, value}]
-      end
-    end)
+  defp replace_entries(data, name, new_entries) do
+    case Enum.find_index(data, fn {n, _} -> n == name end) do
+      nil ->
+        data ++ new_entries
+
+      first_index ->
+        filtered_data = Enum.reject(data, fn {n, _} -> n == name end)
+        {before, after_entries} = Enum.split(filtered_data, first_index)
+        before ++ new_entries ++ after_entries
+    end
   end
 
-  defp append_order(order, name) do
-    if name in order, do: order, else: order ++ [name]
-  end
-
-  defp merge_orders(%__MODULE__{} = fd1, %__MODULE__{} = fd2) do
-    fd1
-    |> ordered_names()
-    |> Enum.concat(Enum.reject(ordered_names(fd2), &Map.has_key?(fd1.data, &1)))
-  end
-
-  defp ordered_names(%__MODULE__{data: data, order: order}) do
-    order ++ Enum.reject(Map.keys(data), &(&1 in order))
-  end
-
-  defp keep_data?(fun, name, values) when is_list(values) do
-    values
-    |> Enum.map(&fun.(%{name: name, value: &1}))
-    |> Enum.any?()
-  end
-
-  defp keep_data?(fun, name, value) do
-    fun.(%{name: name, value: value})
+  defp values_for_name(data, name) do
+    data
+    |> Enum.filter(fn {n, _} -> n == name end)
+    |> Enum.map(fn {_, v} -> v end)
   end
 end

--- a/lib/phoenix_test/form_data.ex
+++ b/lib/phoenix_test/form_data.ex
@@ -5,7 +5,7 @@ defmodule PhoenixTest.FormData do
   alias PhoenixTest.Element.Field
   alias PhoenixTest.Element.Select
 
-  defstruct data: %{}
+  defstruct data: %{}, order: []
 
   def new, do: %__MODULE__{}
 
@@ -44,15 +44,19 @@ defmodule PhoenixTest.FormData do
           end
         end)
 
-      %__MODULE__{form_data | data: new_data}
+      %__MODULE__{form_data | data: new_data, order: append_order(form_data.order, name)}
     else
-      %__MODULE__{form_data | data: Map.put(form_data.data, name, value)}
+      %__MODULE__{
+        form_data
+        | data: Map.put(form_data.data, name, value),
+          order: append_order(form_data.order, name)
+      }
     end
   end
 
-  def merge(%__MODULE__{data: data1}, %__MODULE__{data: data2}) do
+  def merge(%__MODULE__{} = fd1, %__MODULE__{} = fd2) do
     data =
-      Map.merge(data1, data2, fn k, v1, v2 ->
+      Map.merge(fd1.data, fd2.data, fn k, v1, v2 ->
         if allows_multiple_values?(k) do
           Enum.uniq(v1 ++ v2)
         else
@@ -60,11 +64,14 @@ defmodule PhoenixTest.FormData do
         end
       end)
 
-    %__MODULE__{data: data}
+    %__MODULE__{data: data, order: merge_orders(fd1, fd2)}
   end
 
-  def override(%__MODULE__{data: data1}, %__MODULE__{data: data2}) do
-    %__MODULE__{data: Map.merge(data1, data2)}
+  def override(%__MODULE__{} = fd1, %__MODULE__{} = fd2) do
+    %__MODULE__{
+      data: Map.merge(fd1.data, fd2.data),
+      order: merge_orders(fd1, fd2)
+    }
   end
 
   def get_data(%__MODULE__{data: data}, name) do
@@ -74,18 +81,35 @@ defmodule PhoenixTest.FormData do
   def put_data(%__MODULE__{} = form_data, name, value) when is_nil(name) or is_nil(value), do: form_data
 
   def put_data(%__MODULE__{} = form_data, name, value) do
-    %__MODULE__{form_data | data: Map.put(form_data.data, name, value)}
+    %__MODULE__{
+      form_data
+      | data: Map.put(form_data.data, name, value),
+        order: append_order(form_data.order, name)
+    }
   end
 
   defp allows_multiple_values?(field_name), do: String.ends_with?(field_name, "[]")
 
-  def filter(%__MODULE__{data: data}, fun) do
+  def filter(%__MODULE__{} = form_data, fun) do
     data =
-      data
-      |> Enum.filter(fn {name, value} -> fun.(%{name: name, value: value}) end)
-      |> Map.new()
+      form_data
+      |> ordered_names()
+      |> Enum.reduce(%{}, fn name, acc ->
+        value = Map.get(form_data.data, name)
 
-    %__MODULE__{data: data}
+        if keep_data?(fun, name, value) do
+          Map.put(acc, name, value)
+        else
+          acc
+        end
+      end)
+
+    order =
+      form_data
+      |> ordered_names()
+      |> Enum.filter(&Map.has_key?(data, &1))
+
+    %__MODULE__{data: data, order: order}
   end
 
   def empty?(%__MODULE__{data: data}) do
@@ -102,15 +126,41 @@ defmodule PhoenixTest.FormData do
     Map.keys(data)
   end
 
-  def to_list(%__MODULE__{data: data}) do
-    data
-    |> Enum.map(fn
-      {key, values} when is_list(values) ->
-        Enum.map(values, &{key, &1})
+  def to_list(%__MODULE__{} = form_data) do
+    form_data
+    |> ordered_names()
+    |> Enum.flat_map(fn name ->
+      case Map.fetch!(form_data.data, name) do
+        values when is_list(values) ->
+          Enum.map(values, &{name, &1})
 
-      {_key, _value} = field ->
-        field
+        value ->
+          [{name, value}]
+      end
     end)
-    |> List.flatten()
+  end
+
+  defp append_order(order, name) do
+    if name in order, do: order, else: order ++ [name]
+  end
+
+  defp merge_orders(%__MODULE__{} = fd1, %__MODULE__{} = fd2) do
+    fd1
+    |> ordered_names()
+    |> Enum.concat(Enum.reject(ordered_names(fd2), &Map.has_key?(fd1.data, &1)))
+  end
+
+  defp ordered_names(%__MODULE__{data: data, order: order}) do
+    order ++ Enum.reject(Map.keys(data), &(&1 in order))
+  end
+
+  defp keep_data?(fun, name, values) when is_list(values) do
+    values
+    |> Enum.map(&fun.(%{name: name, value: &1}))
+    |> Enum.any?()
+  end
+
+  defp keep_data?(fun, name, value) do
+    fun.(%{name: name, value: value})
   end
 end

--- a/lib/phoenix_test/html.ex
+++ b/lib/phoenix_test/html.ex
@@ -95,6 +95,13 @@ defmodule PhoenixTest.Html do
     end
   end
 
+  def tag(%LazyHTML{} = html) do
+    case element(html) do
+      {tag, _, _} -> to_string(tag)
+      _ -> nil
+    end
+  end
+
   defp normalize_whitespace(string) do
     String.replace(string, ~r/[\s]+/, " ")
   end

--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -595,8 +595,8 @@ defmodule PhoenixTest.Query do
   end
 
   defp selected_option_texts(element) do
-    case Html.element(element) do
-      {"select", _attrs, _children} ->
+    case Html.tag(element) do
+      "select" ->
         element
         |> Html.selected_options()
         |> Enum.map(&Html.element_text/1)

--- a/test/phoenix_test/element/form_test.exs
+++ b/test/phoenix_test/element/form_test.exs
@@ -246,7 +246,7 @@ defmodule PhoenixTest.Element.FormTest do
       assert FormData.has_data?(form.form_data, "checkbox", "checked")
     end
 
-    test "preserves successful control order by field name when submission entries are flattened" do
+    test "preserves successful control DOM order in submission entries" do
       html = """
       <form id="form">
         <input type="hidden" name="mixed_items" value="" />
@@ -261,8 +261,8 @@ defmodule PhoenixTest.Element.FormTest do
       assert FormData.to_list(form.form_data) == [
                {"mixed_items", ""},
                {"mixed_items[]", "one"},
-               {"mixed_items[]", "two"},
-               {"after", "later"}
+               {"after", "later"},
+               {"mixed_items[]", "two"}
              ]
     end
   end

--- a/test/phoenix_test/element/form_test.exs
+++ b/test/phoenix_test/element/form_test.exs
@@ -245,6 +245,26 @@ defmodule PhoenixTest.Element.FormTest do
 
       assert FormData.has_data?(form.form_data, "checkbox", "checked")
     end
+
+    test "preserves successful control order by field name when submission entries are flattened" do
+      html = """
+      <form id="form">
+        <input type="hidden" name="mixed_items" value="" />
+        <input type="checkbox" name="mixed_items[]" value="one" checked />
+        <input type="text" name="after" value="later" />
+        <input type="checkbox" name="mixed_items[]" value="two" checked />
+      </form>
+      """
+
+      form = Form.find!(html, "form")
+
+      assert FormData.to_list(form.form_data) == [
+               {"mixed_items", ""},
+               {"mixed_items[]", "one"},
+               {"mixed_items[]", "two"},
+               {"after", "later"}
+             ]
+    end
   end
 
   describe "form.submit_button" do

--- a/test/phoenix_test/form_data_test.exs
+++ b/test/phoenix_test/form_data_test.exs
@@ -190,6 +190,29 @@ defmodule PhoenixTest.FormDataTest do
 
       assert FormData.to_list(form_data) == [{"items[]", ""}]
     end
+
+    test "preserves field order when user input for checkbox group overrides hidden input" do
+      base =
+        FormData.new()
+        |> FormData.add_data("mixed_items", "")
+        |> FormData.add_data("mixed_items[]", ["one", "two"])
+        |> FormData.add_data("name", "default")
+
+      override =
+        FormData.new()
+        |> FormData.put_data("mixed_items[]", ["one", "two", "three"])
+        |> FormData.put_data("name", "Bilbo")
+
+      form_data = FormData.override(base, override)
+
+      assert FormData.to_list(form_data) == [
+               {"mixed_items", ""},
+               {"mixed_items[]", "one"},
+               {"mixed_items[]", "two"},
+               {"mixed_items[]", "three"},
+               {"name", "Bilbo"}
+             ]
+    end
   end
 
   describe "filter" do
@@ -249,7 +272,7 @@ defmodule PhoenixTest.FormDataTest do
 
       list = FormData.to_list(form_data)
 
-      assert list == [{"email", "frodo@fellowship.com"}, {"name", "frodo"}]
+      assert list == [{"name", "frodo"}, {"email", "frodo@fellowship.com"}]
     end
 
     test "preserves select options ordering" do

--- a/test/phoenix_test/form_payload_test.exs
+++ b/test/phoenix_test/form_payload_test.exs
@@ -2,6 +2,7 @@ defmodule PhoenixTest.FormPayloadTest do
   use ExUnit.Case, async: true
 
   alias PhoenixTest.Element.Form
+  alias PhoenixTest.FormData
   alias PhoenixTest.FormPayload
 
   describe "new" do
@@ -131,6 +132,28 @@ defmodule PhoenixTest.FormPayloadTest do
       form = Form.find!(html, "form")
 
       assert %{"checkbox" => "unchecked"} = FormPayload.new(form.form_data)
+    end
+
+    test "preserves array values when hidden scalar and array entries for multiple fields are interleaved" do
+      form_data =
+        FormData.new()
+        |> FormData.add_data("preferences[color]", "")
+        |> FormData.add_data("preferences[color][]", "blue")
+        |> FormData.add_data("preferences[size]", "")
+        |> FormData.add_data("preferences[size][]", "medium")
+        |> FormData.add_data("preferences[tag]", "")
+        |> FormData.add_data("preferences[tag][]", [
+          "new",
+          "sale"
+        ])
+
+      assert %{
+               "preferences" => %{
+                 "color" => ["blue"],
+                 "size" => ["medium"],
+                 "tag" => ["new", "sale"]
+               }
+             } = FormPayload.new(form_data)
     end
   end
 

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -674,6 +674,18 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("#form-data", text: "three")
     end
 
+    test "submits checked values for checkbox groups when a hidden input uses the non-array name", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within("#mixed-array-checkbox-form", fn session ->
+        check(session, "Mixed Three")
+      end)
+      |> assert_has("#form-data", text: "mixed_items: [")
+      |> assert_has("#form-data", text: "one")
+      |> assert_has("#form-data", text: "two")
+      |> assert_has("#form-data", text: "three")
+    end
+
     test "can re-check an array named checkbox after unchecking it on change", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -558,6 +558,19 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("#form-data", text: "three")
     end
 
+    test "submits checked values for checkbox groups when a hidden input uses the non-array name", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> within("#mixed-array-checkbox-form", fn session ->
+        check(session, "Mixed Three")
+      end)
+      |> submit()
+      |> assert_has("#form-data", text: "mixed_items: [")
+      |> assert_has("#form-data", text: "one")
+      |> assert_has("#form-data", text: "two")
+      |> assert_has("#form-data", text: "three")
+    end
+
     test "can re-check an array named checkbox after unchecking it", %{conn: conn} do
       conn
       |> visit("/page/index")

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -385,6 +385,21 @@ defmodule PhoenixTest.WebApp.IndexLive do
       <button type="submit">Save Array Checkbox Form</button>
     </form>
 
+    <form id="mixed-array-checkbox-form" phx-change="change-form" phx-submit="change-form">
+      <input type="hidden" name="mixed_items" value="" />
+
+      <label for="mixed-array-item-one">Mixed One</label>
+      <input id="mixed-array-item-one" type="checkbox" name="mixed_items[]" value="one" checked />
+
+      <label for="mixed-array-item-two">Mixed Two</label>
+      <input id="mixed-array-item-two" type="checkbox" name="mixed_items[]" value="two" checked />
+
+      <label for="mixed-array-item-three">Mixed Three</label>
+      <input id="mixed-array-item-three" type="checkbox" name="mixed_items[]" value="three" />
+
+      <button type="submit">Save Mixed Array Checkbox Form</button>
+    </form>
+
     <form id="same-labels" phx-submit="save-form" phx-change="change-form">
       <fieldset name="like-elixir">
         <legend>Do you like Elixir:</legend>

--- a/test/support/web_app/page_view.ex
+++ b/test/support/web_app/page_view.ex
@@ -290,6 +290,19 @@ defmodule PhoenixTest.WebApp.PageView do
       <input id="array-item-three" type="checkbox" name="items[]" value="three" />
     </form>
 
+    <form id="mixed-array-checkbox-form" method="post" action="/page/create_record">
+      <input type="hidden" name="mixed_items" value="" />
+
+      <label for="mixed-array-item-one">Mixed One</label>
+      <input id="mixed-array-item-one" type="checkbox" name="mixed_items[]" value="one" checked />
+
+      <label for="mixed-array-item-two">Mixed Two</label>
+      <input id="mixed-array-item-two" type="checkbox" name="mixed_items[]" value="two" checked />
+
+      <label for="mixed-array-item-three">Mixed Three</label>
+      <input id="mixed-array-item-three" type="checkbox" name="mixed_items[]" value="three" />
+    </form>
+
     <form id="same-labels" action="/page/create_record" method="post">
       <fieldset>
         <legend>Do you like Elixir:</legend>


### PR DESCRIPTION
Omit hidden 'reset' input that appears before checkbox group if any checkboxes are checked.

## What changed?
- Better preserve DOM order of form elements better when building form data.

## Why make these changes?
A hidden input before a checkbox group can be used to reset the value if all checkboxes are unchecked.
However, if checkboxes are checked, then the hidden input should be effectively ignored.
Plug/Phoenix can handle this if the field values arrive in DOM order.

In forms like:

```html
<input type="hidden" name="list" value="" />
<input type="checkbox" name="list[]" value="one" />
<input type="checkbox" name="list[]" value="two" />
```

PhoenixTest previously collected controls by selector category and stored `FormData` in a map. That lost DOM order and collapsed repeated field names, which could cause the hidden scalar entry to interfere with the checkbox array payload.

This PR is only a partial improvement. The ideal solution would be to submit form data in the exact DOM order a browser would, end to end.
