### PR TITLE
Support aria-label/aria-labelledBy in click_link/click_button

### DIFF
--- a/lib/phoenix_test.ex
+++ b/lib/phoenix_test.ex
@@ -262,6 +262,12 @@ defmodule PhoenixTest do
   Clicks a link with given text (using a substring match) and performs the
   action.
 
+  In addition to targeting the link via its inner text, you can also target it
+  via `aria-label` or `aria-labelledby`. But note that the link's inner text
+  and any associated `<label>` take precedence over its ARIA attributes, and
+  `aria-label` takes precedence over `aria-labelledby`. This differs from the
+  browser's accessible-name calculation.
+
   Here's how it handles different types of `a` tags:
 
   - With `href`: follows it to the next page
@@ -332,6 +338,13 @@ defmodule PhoenixTest do
   @doc """
   Perfoms action defined by button with given text (using a substring match).
   The action is based on attributes present.
+
+  In addition to targeting the button via text or an input's value, you can
+  also target it via `aria-label` or `aria-labelledby`. But note that the
+  button's inner text, input value, or associated `<label>` takes precedence
+  over its ARIA attributes, and `aria-label` takes precedence over
+  `aria-labelledby`. This differs from the browser's accessible-name
+  calculation.
 
   This can be used in a number of ways.
 
@@ -589,8 +602,13 @@ defmodule PhoenixTest do
   <input id="search" type="text" name="q" />
   ```
 
-  In addition to `<label>` elements, the label can also be the accessible name
-  provided by the input's `aria-label` or `aria-labelledby` attribute:
+  In addition to targeting the field via a `<label>`, you can also target it
+  via `aria-label` or `aria-labelledby`. But note that the `<label>` takes
+  precedence over its ARIA attributes, and `aria-label` takes precedence over
+  `aria-labelledby`. This differs from the browser's accessible-name
+  calculation.
+
+  For example:
 
   ```html
   <input type="text" name="q" aria-label="Search" />
@@ -642,6 +660,12 @@ defmodule PhoenixTest do
 
   @doc """
   Selects an option from a select dropdown.
+
+  In addition to targeting the select via a `<label>`, you can also target it
+  via `aria-label` or `aria-labelledby`. But note that the `<label>` takes
+  precedence over its ARIA attributes, and `aria-label` takes precedence over
+  `aria-labelledby`. This differs from the browser's accessible-name
+  calculation.
 
   ## Options
 
@@ -816,6 +840,12 @@ defmodule PhoenixTest do
   @doc """
   Check a checkbox.
 
+  In addition to targeting the checkbox via a `<label>`, you can also target it
+  via `aria-label` or `aria-labelledby`. But note that the `<label>` takes
+  precedence over its ARIA attributes, and `aria-label` takes precedence over
+  `aria-labelledby`. This differs from the browser's accessible-name
+  calculation.
+
   To uncheck a checkbox, see `uncheck/3`.
 
   ## Options
@@ -918,6 +948,12 @@ defmodule PhoenixTest do
 
   @doc """
   Uncheck a checkbox.
+
+  In addition to targeting the checkbox via a `<label>`, you can also target it
+  via `aria-label` or `aria-labelledby`. But note that the `<label>` takes
+  precedence over its ARIA attributes, and `aria-label` takes precedence over
+  `aria-labelledby`. This differs from the browser's accessible-name
+  calculation.
 
   To check a checkbox, see `check/3`.
 
@@ -1027,6 +1063,12 @@ defmodule PhoenixTest do
 
   @doc """
   Choose a radio button option.
+
+  In addition to targeting the radio button via a `<label>`, you can also
+  target it via `aria-label` or `aria-labelledby`. But note that the `<label>`
+  takes precedence over its ARIA attributes, and `aria-label` takes precedence
+  over `aria-labelledby`. This differs from the browser's accessible-name
+  calculation.
 
   ## Options
 
@@ -1167,6 +1209,12 @@ defmodule PhoenixTest do
 
   @doc """
   Upload a file.
+
+  In addition to targeting the file input via a `<label>`, you can also target
+  it via `aria-label` or `aria-labelledby`. But note that the `<label>` takes
+  precedence over its ARIA attributes, and `aria-label` takes precedence over
+  `aria-labelledby`. This differs from the browser's accessible-name
+  calculation.
 
   If the form is a LiveView form, this will perform a live file upload and trigger the associated `phx-change` event.
 
@@ -1377,8 +1425,9 @@ defmodule PhoenixTest do
   - `label`: the label associated to the form field with `value`, `selected`, or
   `checked`. The association can be a `<label>` element (wrapping the field or
   pointing to it via `for`/`id`), or an accessible name provided by the field's
-  `aria-label` or `aria-labelledby` attribute. Note: if a field is reachable by
-  both a `<label>` and an `aria-*` attribute, the `<label>` match takes precedence.
+  `aria-label` or `aria-labelledby` attribute. But note that a `<label>` takes
+  precedence over its ARIA attributes, and `aria-label` takes precedence over
+  `aria-labelledby`. This differs from the browser's accessible-name calculation.
 
   - `exact`: by default `assert_has/3` will perform a substring match (e.g. `a
   =~ b`). That makes it easier to assert text within HTML elements that also
@@ -1520,8 +1569,9 @@ defmodule PhoenixTest do
   - `label`: the label associated to the form field with `value`, `selected`, or
   `checked`. The association can be a `<label>` element (wrapping the field or
   pointing to it via `for`/`id`), or an accessible name provided by the field's
-  `aria-label` or `aria-labelledby` attribute. Note: if a field is reachable by
-  both a `<label>` and an `aria-*` attribute, the `<label>` match takes precedence.
+  `aria-label` or `aria-labelledby` attribute. But note that a `<label>` takes
+  precedence over its ARIA attributes, and `aria-label` takes precedence over
+  `aria-labelledby`. This differs from the browser's accessible-name calculation.
 
   - `exact`: by default `refute_has/3` will perform a substring match (e.g. `a
   =~ b`). That makes it easier to refute text within HTML elements that also

--- a/lib/phoenix_test/element/link.ex
+++ b/lib/phoenix_test/element/link.ex
@@ -1,6 +1,7 @@
 defmodule PhoenixTest.Element.Link do
   @moduledoc false
 
+  alias PhoenixTest.Element
   alias PhoenixTest.Html
   alias PhoenixTest.Query
   alias PhoenixTest.Utils
@@ -8,13 +9,26 @@ defmodule PhoenixTest.Element.Link do
   defstruct ~w[parsed id selector text href]a
 
   def find(html, selector, text) do
-    with {:found, link} <- Query.find(html, selector, text) do
-      {:found, build(link, selector, text)}
+    case Query.find(html, selector, text) do
+      {:found, link} ->
+        {:found, build(link, selector, text)}
+
+      {:not_found, _potential_matches} = not_found ->
+        case Query.find_by_label(html, selector, text, exact: false) do
+          {:found, link} -> {:found, build(link, Element.build_selector(link), Html.element_text(link))}
+          _ -> not_found
+        end
+
+      other ->
+        other
     end
   end
 
   def find!(html, selector, text) do
-    html |> Query.find!(selector, text) |> build(selector, text)
+    case find(html, selector, text) do
+      {:found, link} -> link
+      _ -> html |> Query.find!(selector, text) |> build(selector, text)
+    end
   end
 
   defp build(link, selector, text) do

--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -75,12 +75,19 @@ defmodule PhoenixTest.Live do
     session = set_operation(session, :click_link)
     selector = scope_selector(selector, session.within)
 
-    with {:found, link} <- PhoenixTest.Element.Link.find(session.current_operation.html, selector, text),
-         true <- PhoenixTest.Element.Link.has_data_method?(link) do
-      %{session.conn | resp_body: session.current_operation.html}
-      |> PhoenixTest.Static.build()
-      |> PhoenixTest.Static.click_with_data_method(link)
-    else
+    case PhoenixTest.Element.Link.find(session.current_operation.html, selector, text) do
+      {:found, link} ->
+        if PhoenixTest.Element.Link.has_data_method?(link) do
+          %{session.conn | resp_body: session.current_operation.html}
+          |> PhoenixTest.Static.build()
+          |> PhoenixTest.Static.click_with_data_method(link)
+        else
+          session.view
+          |> element(scope_selector(link.selector, session.within), link.text)
+          |> render_click()
+          |> maybe_redirect(session)
+        end
+
       _ ->
         session.view
         |> element(selector, text)

--- a/lib/phoenix_test/query.ex
+++ b/lib/phoenix_test/query.ex
@@ -130,10 +130,22 @@ defmodule PhoenixTest.Query do
     end
   end
 
-  def find_by_role!(html, locator) do
-    selectors = Locators.role_selectors(locator)
+  def find_by_role!(html, %Locators.Button{text: text, selectors: button_selectors} = locator) do
+    role_selectors = Locators.role_selectors(locator)
 
-    find_one_of!(html, selectors)
+    case find_one_of(html, role_selectors) do
+      {:found, element} ->
+        element
+
+      {:not_found, _potential_matches} ->
+        case find_by_label(html, button_selectors, text, exact: false) do
+          {:found, element} -> element
+          _ -> find_one_of!(html, role_selectors)
+        end
+
+      {:found_many, _elements} ->
+        find_one_of!(html, role_selectors)
+    end
   end
 
   def find_one_of!(html, elements) do

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -70,6 +70,20 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("h1", text: "LiveView main page")
     end
 
+    test "finds link by aria label", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_link("Navigate-me-aria")
+      |> assert_has("h1", text: "LiveView page 2")
+    end
+
+    test "finds link by aria labelledby", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_link("Navigate-me-labelledby")
+      |> assert_has("h1", text: "LiveView page 2")
+    end
+
     test "accepts click_link with selector", %{conn: conn} do
       conn
       |> visit("/live/index")
@@ -146,6 +160,20 @@ defmodule PhoenixTest.LiveTest do
       conn
       |> visit("/live/index")
       |> click_button("Show")
+      |> assert_has("#tab", text: "Tab title")
+    end
+
+    test "finds button by aria label", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_button("Show-me-aria")
+      |> assert_has("#tab", text: "Tab title")
+    end
+
+    test "finds button by aria labelledby", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> click_button("Show-me-labelledby")
       |> assert_has("#tab", text: "Tab title")
     end
 

--- a/test/phoenix_test/static_test.exs
+++ b/test/phoenix_test/static_test.exs
@@ -59,6 +59,20 @@ defmodule PhoenixTest.StaticTest do
       |> assert_has("h1", text: "Main page")
     end
 
+    test "finds link by aria label", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> click_link("Go-to-page-2-aria")
+      |> assert_has("h1", text: "Page 2")
+    end
+
+    test "finds link by aria labelledby", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> click_link("Go-to-page-2-labelledby")
+      |> assert_has("h1", text: "Page 2")
+    end
+
     test "accepts selector for link", %{conn: conn} do
       conn
       |> visit("/page/index")
@@ -149,6 +163,20 @@ defmodule PhoenixTest.StaticTest do
       conn
       |> visit("/page/index")
       |> click_button("Get")
+      |> assert_has("h1", text: "Record received")
+    end
+
+    test "finds button by aria label", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> click_button("get-me-aria")
+      |> assert_has("h1", text: "Record received")
+    end
+
+    test "finds button by aria labelledby", %{conn: conn} do
+      conn
+      |> visit("/page/index")
+      |> click_button("get-me-labelledby")
       |> assert_has("h1", text: "Record received")
     end
 

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -10,6 +10,9 @@ defmodule PhoenixTest.WebApp.IndexLive do
     <h1 id="title" class="title" data-role="title">LiveView main page</h1>
 
     <.link navigate="/live/page_2?details=true&foo=bar">Navigate link</.link>
+    <.link navigate="/live/page_2" aria-label="Navigate-me-aria">asdfsda</.link>
+    <span id="navigate-me-labelledby">Navigate-me-labelledby</span>
+    <.link navigate="/live/page_2" aria-labelledby="navigate-me-labelledby">asdfsda</.link>
     <.link patch="/live/index?details=true&foo=bar">Patch link</.link>
     <.link href="/page/index?details=true&foo=bar">Navigate to non-liveview</.link>
     <.link navigate="/page/index">Navigate with navigate to dead view</.link>
@@ -40,6 +43,9 @@ defmodule PhoenixTest.WebApp.IndexLive do
     <button phx-click="change-page-title">Change page title</button>
 
     <button phx-click="show-tab">Show tab</button>
+    <button phx-click="show-tab" aria-label="Show-me-aria">asdfsda</button>
+    <span id="show-me-labelledby">Show-me-labelledby</span>
+    <button phx-click="show-tab" aria-labelledby="show-me-labelledby">asdfsda</button>
 
     <a
       href="/page/delete_record"

--- a/test/support/web_app/page_view.ex
+++ b/test/support/web_app/page_view.ex
@@ -6,6 +6,9 @@ defmodule PhoenixTest.WebApp.PageView do
     <h1 id="title" class="title" data-role="title">Main page</h1>
 
     <a href="/page/page_2?foo=bar">Page 2</a>
+    <a href="/page/page_2" aria-label="Go-to-page-2-aria">asdfsda</a>
+    <span id="go-to-page-2-labelledby">Go-to-page-2-labelledby</span>
+    <a href="/page/page_2" aria-labelledby="go-to-page-2-labelledby">asdfsda</a>
 
     <a href="/page/no_page?redirect_to=/page/index">Navigate away and redirect back</a>
 
@@ -47,6 +50,15 @@ defmodule PhoenixTest.WebApp.PageView do
 
     <form action="/page/get_record">
       <button>Get record</button>
+    </form>
+
+    <form action="/page/get_record">
+      <button aria-label="get-me-aria">adfad</button>
+    </form>
+
+    <span id="get-me-labelledby">get-me-labelledby</span>
+    <form action="/page/get_record">
+      <button aria-labelledby="get-me-labelledby">adfad</button>
     </form>
 
     <form action="/page/update_record" method="post">


### PR DESCRIPTION
Closes #243 

#319  added support for finding elements by `aria-label` and `aria-labelledby` for form actions and assertions (basically, anything that was using `Query.find_by_label`)

Our `click_link` and `click_button` weren't using that helper, so they did not get the same treatment. This commit updates those helpers so they too support finding by `aria-label` and `aria-labelledBy`