### PR TITLE
Fix double scoping of links

### DIFF
--- a/lib/phoenix_test/live.ex
+++ b/lib/phoenix_test/live.ex
@@ -83,7 +83,7 @@ defmodule PhoenixTest.Live do
           |> PhoenixTest.Static.click_with_data_method(link)
         else
           session.view
-          |> element(scope_selector(link.selector, session.within), link.text)
+          |> element(link.selector, link.text)
           |> render_click()
           |> maybe_redirect(session)
         end

--- a/test/phoenix_test/live_test.exs
+++ b/test/phoenix_test/live_test.exs
@@ -91,6 +91,15 @@ defmodule PhoenixTest.LiveTest do
       |> assert_has("h1", text: "LiveView page 2")
     end
 
+    test "clicks a link within a scoped selector", %{conn: conn} do
+      conn
+      |> visit("/live/index")
+      |> within(".wibble", fn session ->
+        click_link(session, "Scoped link")
+      end)
+      |> assert_path("/live/page_2")
+    end
+
     test "handles patches to current view", %{conn: conn} do
       conn
       |> visit("/live/index")

--- a/test/support/web_app/index_live.ex
+++ b/test/support/web_app/index_live.ex
@@ -29,9 +29,11 @@ defmodule PhoenixTest.WebApp.IndexLive do
     <div>
       <div class="wibble">
         <button phx-click="do-it">action</button>
+        <.link navigate="/live/page_2">Scoped link</.link>
       </div>
       <div class="wobble">
         <button phx-click="do-it">action</button>
+        <.link navigate="/live/page_2">Scoped link</.link>
       </div>
     </div>
 


### PR DESCRIPTION
Closes #321 

What changed?
=============

A previous commit introduced a regression where we accidentally double scoped certain `click_link` actions in `live.ex`

This commit fixes the regression.